### PR TITLE
Feature: Detailed previewing pages

### DIFF
--- a/src/assets/pokeball.svg
+++ b/src/assets/pokeball.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
+ <g>
+  <circle cx="105" cy="148.5" r="47" stroke-width=".4553"/>
+  <g transform="translate(2.5e-6,103.5)">
+   <path d="m150 45a45 45 0 0 1-22.5 38.971 45 45 0 0 1-45-1e-5 45 45 0 0 1-22.5-38.971h45z" fill="#fff" stroke-width=".25176"/>
+   <path d="m60 45a45 45 0 0 1 45-45 45 45 0 0 1 45 45h-45z" fill="#ce0000" stroke-width=".25176"/>
+  </g>
+  <g transform="translate(-.25568 52.997)">
+   <rect x="56.27" y="90.503" width="97.971" height="10" rx="4.7572" ry="5" stroke-width=".15343"/>
+   <g transform="translate(7.5968 -57.289)">
+    <circle cx="97.659" cy="152.79" r="15" stroke-width=".16253"/>
+    <circle cx="97.659" cy="152.79" r="10" fill="#fff" stroke-width=".10835"/>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/src/components/PokemonPreviewCard.tsx
+++ b/src/components/PokemonPreviewCard.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react";
+import useOnScreen from "../hooks/useOnScreen";
+import { getPokemonData } from "../functions/poke-functions";
+import { PokemonData } from "../types/pokemon-related-types";
+import { Link } from "react-router-dom";
+import RotatingPokeballFeedback from "./feedbacks/RotatingPokeballFeedback";
+
+function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
+  const ref = useRef(null)
+  const { isVisible } = useOnScreen(ref)
+  const [pokemonData, setPokemonData] = useState<PokemonData | null>(null);
+
+
+  useEffect(() => {
+    if (isVisible && pokemonData === null) {
+      getPokemonData(id).then(data => setPokemonData(data))
+    }
+  }, [isVisible]);
+
+  if (pokemonData === null) {
+    return (
+      <div ref={ref}>
+        <h1>{name}</h1>
+        <RotatingPokeballFeedback pokemonId={id}/>
+        <h1>Loading...</h1>
+      </div>
+    )
+  }
+
+  return (
+    <Link to={`/pokemon/${pokemonData.id}`}>
+      <div ref={ref}>
+        <h1>{pokemonData.name}</h1>
+        <img src={pokemonData.spriteSrc} alt={`pokemon ${pokemonData.name}`} style={{maxWidth: 350, maxHeight: 350}}/>
+        <h1>{pokemonData.id}</h1>
+      </div>
+    </Link>
+  )
+}
+
+export default PokemonPreviewCard

--- a/src/components/Rotate.tsx
+++ b/src/components/Rotate.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+import styled, { keyframes } from "styled-components";
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const Rotating = styled.div`
+  animation: ${rotate} 1s linear infinite;
+`
+
+function Rotate({ children }: { children: ReactNode }) {
+  return (
+    <Rotating>
+      { children }
+    </Rotating>
+  )
+}
+
+export default Rotate;

--- a/src/components/feedbacks/RotatingPokeballFeedback.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedback.tsx
@@ -1,0 +1,12 @@
+import Rotate from "../Rotate"
+import PokeballSVG from '../assets/pokeball.svg'
+
+function RotatingPokeballFeedback({ pokemonId }: { pokemonId: number }) {
+  return (
+    <Rotate>
+      <img src={PokeballSVG} alt={`Loading pokemon ${pokemonId}`} style={{maxWidth: 500, maxHeight: 500}}/>
+    </Rotate>
+  )
+}
+
+export default RotatingPokeballFeedback

--- a/src/functions/poke-functions.ts
+++ b/src/functions/poke-functions.ts
@@ -64,6 +64,10 @@ function getPokemonPreviewDataFromArray(arr: NamedAPIResource[]): PokemonPreview
   }))
 }
 
+function removeNonPokemonSpeciesObjectsFromArray(arr: PokemonPreviewData[]): PokemonPreviewData[] {
+  return arr.filter(item => item.id < 10000)
+}
+
 function getGenRegion(gen: number) {
   switch (gen) {
     case 1: 
@@ -117,5 +121,6 @@ export {
   getMaxNumberOfPokemons, 
   getGenRegion,
   getPokemonPreviewDataFromArray,
-  sanitizeTypes
+  sanitizeTypes,
+  removeNonPokemonSpeciesObjectsFromArray
 }

--- a/src/functions/testing.test.ts
+++ b/src/functions/testing.test.ts
@@ -1,7 +1,17 @@
 import { expect, test } from '@jest/globals'
+import { removeNonPokemonSpeciesObjectsFromArray } from './poke-functions'
+import { NamedAPIResource } from '../types/pokemon-related-types'
 
 
+test('testing', async () => {
+  const res = await fetch('https://pokeapi.co/api/v2/type/12')
+  const rawData = await res.json()
+  const filtered: NamedAPIResource[] = rawData.pokemon.map((item: {
+    pokemon: NamedAPIResource,
+    slot: number
+  }) => item.pokemon)
+  const a = removeNonPokemonSpeciesObjectsFromArray(filtered)
+  const b = a.filter(item => item.name === 'shaymin-sky')
 
-test('testing', () => {
-  expect(!true).toBe(false)
+  expect(b).toBe([undefined])
 })

--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -27,7 +27,9 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
       } else {
         filteredPreviewData.current = getCommonItemsFromObjectArrays(filteredPreviewData.current, result, 'name')
       }
+    }
 
+    if (filteredPreviewData.current !== null) {
       filteredPreviewData.current.sort((a,b) => a.id - b.id)
     }
   }

--- a/src/hooks/usePokemonsPreviewDataTypes.ts
+++ b/src/hooks/usePokemonsPreviewDataTypes.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { getCommonItemsFromObjectArrays } from "../functions/other-functions"
 import { NamedAPIResource, NamedAPIResourceList, PokemonPreviewData, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
-import { sanitizeTypes, getPokemonPreviewDataFromArray } from "../functions/poke-functions"
+import { sanitizeTypes, getPokemonPreviewDataFromArray, removeNonPokemonSpeciesObjectsFromArray } from "../functions/poke-functions"
 
 function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus {
   const pokemonTypes = sanitizeTypes(types) 
@@ -15,8 +15,12 @@ function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus
   
   
   const { data, isLoading } = useQuery({
-    queryKey: [pokemonTypes],
-    queryFn: async () => await getPokemonsPreviewDataFromTypes(pokemonTypes)
+    queryKey: pokemonTypes,
+    queryFn: async () => {
+      const previewData = await getPokemonsPreviewDataFromTypes(pokemonTypes)
+
+      return previewData && removeNonPokemonSpeciesObjectsFromArray(previewData)
+    }
   }) 
 
   return ({

--- a/src/pages/Filtered.tsx
+++ b/src/pages/Filtered.tsx
@@ -1,6 +1,6 @@
-import { Link } from "react-router-dom"
 import useFilteredPokemonsPreviewData from "../hooks/useFilteredPokemonsPreviewData"
 import useURLSearchParams from "../hooks/useURLSearchParams"
+import PokemonPreviewCard from "../components/PokemonPreviewCard"
 
 function Filtered() {
   const searchParams = useURLSearchParams()
@@ -20,12 +20,11 @@ function Filtered() {
     <>
       <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
       {previewData.map(fetchedPokemon => (
-        <Link to={`/pokemon/${fetchedPokemon.id}`} key={fetchedPokemon.id}>
-          <div>
-            <h3>{fetchedPokemon.name}</h3>
-            <h3>{fetchedPokemon.id}</h3>
-          </div>
-        </Link>
+        <PokemonPreviewCard 
+          id={fetchedPokemon.id}
+          name={fetchedPokemon.name}
+          key={`pokemon-${fetchedPokemon.id}`}
+        />
       ))}
       </div>
     </>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,7 @@
-import { Link } from "react-router-dom";
 import usePokemonsPreviewData from "../hooks/usePokemonsPreviewData";
 import { useEffect, useState } from "react";
 import { PokemonPreviewData } from "../types/pokemon-related-types";
+import PokemonPreviewCard from "../components/PokemonPreviewCard";
 
 function Home() {
   const { previewData, isLoading, fetchNextPokemons } = usePokemonsPreviewData(200)
@@ -16,20 +16,16 @@ function Home() {
   if (fetchedPokemons.length === 0) {
     return <h1>Loading...</h1>
   }
-  // if (isLoading === true && previewData === null) it is still loading
-  // if (isLoading === false && previewData !== null) is has retrieved data
-  // if (isLoading === false && previewData === null) it has no data to retrieve
 
   return (
     <>
       <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
       {fetchedPokemons.map(fetchedPokemon => (
-        <Link to={`/pokemon/${fetchedPokemon.id}`}  key={fetchedPokemon.id}>
-          <div>
-            <h3>{fetchedPokemon.name}</h3>
-            <h3>{fetchedPokemon.id}</h3>
-          </div>
-        </Link>
+        <PokemonPreviewCard 
+          id={fetchedPokemon.id} 
+          name={fetchedPokemon.name} 
+          key={`pokemon-${fetchedPokemon.id}`}
+        />
       ))}
       {isLoading && <h1>...Loading more pokemons</h1>}
       </div>

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -8,12 +8,12 @@ import { useQuery } from "@tanstack/react-query"
 function SinglePokemon() {
   const { id } = useParams()
   const pokemonId = Number(id)
-  const { data, isPending } = useQuery({ 
-    queryKey: ['pokemon_data', pokemonId],
+  const { data, isLoading } = useQuery({ 
+    queryKey: [pokemonId],
     queryFn: async () => await getPokemonData(pokemonId)
   })
     
-  if (isPending || data === undefined) return <h1>Loading...</h1>
+  if (isLoading || data === undefined) return <h1>Loading...</h1>
   else if (data === null) return <h1>Sorry, no pokemon found with this id.</h1>
 
   return (


### PR DESCRIPTION
## Description

Detailed previewing pages.

## Images (optional)

None.

## Current behavior

Simply displaying id and name and wrapping them with a link component that leads to the "detailed pokemon" page.

## Expected behavior

Display a card-like component with name, id, and picture of the pokemon and wrapping it in a link component aswell, card pending stylization based on pokemon type.

## Describe changes

- New component handling the data display (PokemonPreviewCard).
- New Feedback to be used instead of pokemon image while loading of data to display (RotatingPokeballFeedback).
- New hook handling lazy-loading (useOnScreen).

## Requirements

- Fetching pokemons data in previewing pages.
- Lazy-loading and infinite scrolling for performance optimization.
- Loading feedback for loading data.