### PR TITLE
fixed: pokeball svg import

### DIFF
--- a/src/assets/pokeball.svg
+++ b/src/assets/pokeball.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="210mm" height="297mm" version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
+<svg version="1.1" viewBox="0 0 210 297" xmlns="http://www.w3.org/2000/svg">
  <g>
   <circle cx="105" cy="148.5" r="47" stroke-width=".4553"/>
   <g transform="translate(2.5e-6,103.5)">

--- a/src/components/feedbacks/RotatingPokeballFeedback.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedback.tsx
@@ -1,10 +1,10 @@
 import Rotate from "../Rotate"
-import PokeballSVG from '../assets/pokeball.svg'
+import PokeballSVG from '../../assets/pokeball.svg'
 
 function RotatingPokeballFeedback({ pokemonId }: { pokemonId: number }) {
   return (
     <Rotate>
-      <img src={PokeballSVG} alt={`Loading pokemon ${pokemonId}`} style={{maxWidth: 500, maxHeight: 500}}/>
+      <img src={PokeballSVG} alt={`Loading pokemon ${pokemonId}`} style={{width: 500, height: 500}}/>
     </Rotate>
   )
 }


### PR DESCRIPTION
## Description

PokeballSVG was not properly imported.

## Images (optional)

None.

## Current behavior

Pokeball SVG was not properly imported, source string is incorrect, resulting in a error.

## Expected behavior

Pokeball SVG properly imported with the correct source string, no errors.

## Describe changes

Changed import statement in "RotatingPokeballFeedback,.tsx", while at it, also removed the width and height property which were set in the "svg" tag in the original "pokeball.svg" file.