### PR TITLE
fixed: single pokemon page data caching is off

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/usePokemonsPreviewDataGen.ts
+++ b/src/hooks/usePokemonsPreviewDataGen.ts
@@ -10,7 +10,7 @@ function usePokemonsPreviewDataGen(gen: number): PokemonsPreviewDataStatus {
   })
 
   const { data, isLoading } = useQuery({
-    queryKey: [gen],
+    queryKey: ['pokemonGen', gen],
     queryFn: async () => await getPokemonsPreviewDataFromGen(gen)
   })
 

--- a/src/hooks/usePokemonsPreviewDataTypes.ts
+++ b/src/hooks/usePokemonsPreviewDataTypes.ts
@@ -13,9 +13,8 @@ function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus
     })
   } 
   
-  
   const { data, isLoading } = useQuery({
-    queryKey: pokemonTypes,
+    queryKey: ['pokemonTypes', ...pokemonTypes],
     queryFn: async () => {
       const previewData = await getPokemonsPreviewDataFromTypes(pokemonTypes)
 

--- a/src/hooks/useSinglePokemonData.ts
+++ b/src/hooks/useSinglePokemonData.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query"
+import { getPokemonData } from "../functions/poke-functions"
+import { PokemonData } from "../types/pokemon-related-types"
+
+function useSinglePokemonData(pokemonId: number): 
+{ 
+  data: PokemonData | null,
+  isLoading: boolean
+} {
+  const { data, isLoading } = useQuery({ 
+    queryKey: ['pokemonId', pokemonId],
+    queryFn: async () => await getPokemonData(pokemonId)
+  })
+
+  return {
+    data: data ? data : null,
+    isLoading
+  }
+}
+
+export default useSinglePokemonData

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -1,19 +1,16 @@
-import { getGenRegion, getPokemonData } from "../functions/poke-functions"
+import { getGenRegion } from "../functions/poke-functions"
 import { capitalize } from "../functions/other-functions"
 import { Link, useParams } from "react-router-dom"
-import { useQuery } from "@tanstack/react-query"
+import useSinglePokemonData from "../hooks/useSinglePokemonData"
 
 // TODO: styling
 
 function SinglePokemon() {
   const { id } = useParams()
   const pokemonId = Number(id)
-  const { data, isLoading } = useQuery({ 
-    queryKey: [pokemonId],
-    queryFn: async () => await getPokemonData(pokemonId)
-  })
+  const { data, isLoading } = useSinglePokemonData(pokemonId)
     
-  if (isLoading || data === undefined) return <h1>Loading...</h1>
+  if (isLoading) return <h1>Loading...</h1>
   else if (data === null) return <h1>Sorry, no pokemon found with this id.</h1>
 
   return (


### PR DESCRIPTION
## Description

"Single pokemon" page fetched data is being cached in a wrong way. 
Because of a badly implemented "queryKey" array which is being passed to the "useQuery" hook in "usePokemonsPreviewDataGen" hook, whenever trying to navigate from "Filtered pokemon" page to "Single pokemon" page, the "useQuery" hook identifies that the id provided used in the "queryKey" of that hook instance is already cached and does not try to fetch the data again, however, the data cached is not of type "PokemonData | null" instead it is of type "PokemonPreviewData[] | null".

## Images (optional)

None.

## Current behavior

"Single pokemon" page cached data is conflicting with "Filtered pokemon" page cached data.

## Expected behavior

"Single pokemon" page cached data not in conflict with "Filtered pokemon" page cached data.

## Describe changes

Correct implementation of the "queryKey" array in all "useQuery" hook instances used throughout the source code in order to prevent future caching problems.