### PR TITLE
feature: optimized api caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
+  "homepage": "arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {
     "uncheck-build": "vite build",
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,22 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom"
+import { Routes, Route } from "react-router-dom"
 import Home from "./pages/Home"
 import SinglePokemon from "./pages/SinglePokemon"
 import Redirect from "./pages/Redirect"
 import NavigationHeader from "./components/NavigationHeader"
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
 import Filtered from "./pages/Filtered"
 
-const queryClient = new QueryClient()
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename="/really-simple-pokedex-app/">
-        <NavigationHeader/>
-        <Routes>
-          <Route path={"/"} element={<Home/>}/>
-          <Route path={"/pokemon/:id"} element={<SinglePokemon/>}/>
-          <Route path={"/filtered"} element={<Filtered/>}/>
-          <Route path="*" element={<Redirect destination="/"/>}/>
-        </Routes>
-      </BrowserRouter>
-    </QueryClientProvider>
+    <>
+      <NavigationHeader/>
+      <Routes>
+        <Route path={"/"} element={<Home/>}/>
+        <Route path={"/pokemon/:id"} element={<SinglePokemon/>}/>
+        <Route path={"/filtered"} element={<Filtered/>}/>
+        <Route path="*" element={<Redirect destination="/"/>}/>
+      </Routes>
+    </>
   )
 }
 

--- a/src/functions/other-functions.ts
+++ b/src/functions/other-functions.ts
@@ -1,5 +1,3 @@
-import { PokemonPreviewData } from "../types/pokemon-related-types"
-
 /**
  * Checks if a number is a natural number (0,1,2,3,4,...,n) or not.
  * 

--- a/src/functions/testing.test.ts
+++ b/src/functions/testing.test.ts
@@ -2,5 +2,35 @@ import { expect, test } from '@jest/globals'
 
 
 test('testing', async () => {
-  expect(Boolean(0)).toBe(true)
+  const fam = ['father', 'son1', 'son2', 'mother', 'daughter1']
+  const par = ['mother', 'father']
+  // const woman = ['mother']
+
+  const some = [fam, par]
+
+  function getCommon(arr: string[], arr2: string[]) {
+    let resultarr = []
+    
+    for (const item of arr) {
+      for (const item2 of arr2) {
+        if (item === item2) resultarr.push(item)
+      }
+    }
+
+    return resultarr
+  }
+
+  const sanitized = some.filter(item => item !== null)
+
+  const res = sanitized.reduce((prev, curr, index) => {
+    if (index === 0) return curr
+
+    return getCommon(prev!, curr!)
+  })
+
+  expect(res).toStrictEqual(['father', 'mother'])
+
+  // const array: number[] = []
+
+  // expect(array.reduce((prev, curr) =>  prev + curr, []))
 })

--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -1,8 +1,7 @@
-import { PokemonFilteringOptions, PokemonPreviewData, PokemonsPreviewDataStatus } from "../types/pokemon-related-types";
+import { PokemonFilteringOptions, PokemonsPreviewDataStatus } from "../types/pokemon-related-types";
 import usePokemonsPreviewDataGen from "./usePokemonsPreviewDataGen";
 import usePokemonsPreviewDataTypes from "./usePokemonsPreviewDataTypes";
 import { getCommonItemsFromObjectArrays, isObjectEmpty } from "../functions/other-functions";
-import { useRef } from "react";
 
 function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): PokemonsPreviewDataStatus {
   if (isObjectEmpty(options)) {
@@ -14,28 +13,17 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
 
   const { isLoading: isLoadingGen, previewData: previewDataGen } = usePokemonsPreviewDataGen(Number(options.gen))
   const { isLoading: isLoadingTypes, previewData: previewDataTypes } = usePokemonsPreviewDataTypes(options.types ?? [])
-  
-  const filteredPreviewData = useRef<PokemonPreviewData[] | null>(null)
 
-  const some = [previewDataGen, previewDataTypes]
-  if (isLoadingGen === false && isLoadingTypes === false) {
-    for (const result of some) {
-      if (result === null) continue
-      
-      if (filteredPreviewData.current === null) {
-        filteredPreviewData.current = result
-      } else {
-        filteredPreviewData.current = getCommonItemsFromObjectArrays(filteredPreviewData.current, result, 'name')
-      }
-    }
+  const sanitized = [previewDataGen, previewDataTypes].filter(item => item !== null)
 
-    if (filteredPreviewData.current !== null) {
-      filteredPreviewData.current.sort((a,b) => a.id - b.id)
-    }
-  }
+  const res = sanitized.reduce((prev, curr, index) => {
+    if (index === 0) return curr
+
+    return getCommonItemsFromObjectArrays(prev!, curr!, 'name')
+  }, [])
 
   return { 
-    previewData: filteredPreviewData.current, 
+    previewData: res!.length !== 0 ? res! : null, 
     isLoading: isLoadingTypes || isLoadingGen
   }
 }

--- a/src/hooks/usePokemonsPreviewData.ts
+++ b/src/hooks/usePokemonsPreviewData.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { NamedAPIResourceList, PokemonsPreviewDataStatus } from '../types/pokemon-related-types';
 import { useQuery } from '@tanstack/react-query';
+import { getPokemonPreviewDataFromArray } from '../functions/poke-functions';
 
 
 function usePokemonsPreviewData(limit = 20): PokemonsPreviewDataStatus & { fetchNextPokemons: () => void } {
@@ -13,10 +14,7 @@ function usePokemonsPreviewData(limit = 20): PokemonsPreviewDataStatus & { fetch
       const rawData: NamedAPIResourceList = await res.json()
       
       return {
-        previewData: rawData.results.map(result => ({
-            id: Number(result.url.split('/')[6]),
-            name: result.name
-        })),
+        previewData: getPokemonPreviewDataFromArray(rawData.results),
         nextFetch: rawData.next
       }
     }

--- a/src/hooks/usePokemonsPreviewDataGen.ts
+++ b/src/hooks/usePokemonsPreviewDataGen.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { isInRange, isNaturalNumber } from "../functions/other-functions"
-import { Generation, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
+import { GenPage, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
+import { getPokemonPreviewDataFromArray } from "../functions/poke-functions"
 
 function usePokemonsPreviewDataGen(gen: number): PokemonsPreviewDataStatus {
   // Param handling
@@ -21,12 +22,9 @@ function usePokemonsPreviewDataGen(gen: number): PokemonsPreviewDataStatus {
 
   async function getPokemonsPreviewDataFromGen(gen: number) {
     const res = await fetch(`https://pokeapi.co/api/v2/generation/${gen}`)
-    const rawData: Generation = await res.json()
+    const rawData: GenPage = await res.json()
 
-    return rawData.pokemon_species.map(pokemonSpecie => ({
-      id: Number(pokemonSpecie.url.split('/')[6]),
-      name: pokemonSpecie.name
-    }))
+    return getPokemonPreviewDataFromArray(rawData.pokemon_species)
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,17 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { BrowserRouter } from "react-router-dom"
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
+
+const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter basename="/really-simple-pokedex-app/">
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/src/pages/Filtered.tsx
+++ b/src/pages/Filtered.tsx
@@ -8,13 +8,12 @@ function Filtered() {
     gen: Number(searchParams.gen),
     types: [searchParams.type1, searchParams.type2]
   }) 
-  
-  if (previewData === null) {
-    return isLoading ? 
-    <h1>Loading...</h1> :
-    <h1>Sorry, no pokemons found, you might have mistyped the gen or the pokemons' types</h1>
+
+  if (isLoading) {
+    return <h1>Loading...</h1>
+  } else if (previewData === null) {
+    return <h1>Sorry, no pokemons found, try less options or check if the current ones are typed correctly.</h1>
   }
-  if (previewData.length === 0) return <h1>Sorry, no pokemons found</h1>
 
   return (
     <>

--- a/src/types/pokemon-related-types.ts
+++ b/src/types/pokemon-related-types.ts
@@ -1,9 +1,9 @@
-export type PokemonType = {
-  slot: number, 
+type PokemonType = {
   type: NamedAPIResource
+  slot: number, 
 }
 
-export type PokedexEntry = { 
+type PokedexEntry = { 
   flavor_text: string,
   language: NamedAPIResource,
   version: NamedAPIResource
@@ -48,7 +48,12 @@ export type Name = {
   language: NamedAPIResource
 }
 
-export type Generation = {
+export type PokemonsPreviewDataStatus = {
+  previewData: PokemonPreviewData[] | null,
+  isLoading: boolean
+}
+
+export type GenPage = {
   id: number,
   name: string,
   abilities: NamedAPIResource[],
@@ -60,8 +65,348 @@ export type Generation = {
   version_groups: NamedAPIResource[]
 }
 
-export type PokemonsPreviewDataStatus = {
-  previewData: PokemonPreviewData[] | null,
-  isLoading: boolean
+type FormDescription = {
+  description: string,
+  language: NamedAPIResource 
 }
 
+type Genera = {
+  genus: string,
+  language: NamedAPIResource
+}
+
+type PalParkEncounter = {
+  area: NamedAPIResource,
+  base_score: number,
+  rate: number
+}
+
+type PokedexNumber = {
+  entry_number: number,
+  pokedex: NamedAPIResource
+}
+
+type Variety = {
+  is_default: boolean,
+  pokemon: NamedAPIResource
+}
+
+export type SpeciesPage = {
+  base_hapiness: number,
+  capture_rate: number,
+  color: NamedAPIResource,
+  egg_groups: NamedAPIResource[],
+  evolution_chain: { url: string },
+  evolves_from_species: NamedAPIResource | null,
+  flavor_text_entries: PokedexEntry[],
+  form_description: FormDescription[],
+  forms_switchable: boolean,
+  gender_rate: number,
+  genera: Genera[],
+  generation: NamedAPIResource,
+  growth_rate: NamedAPIResource,
+  habitat: NamedAPIResource,
+  has_gender_differences: boolean,
+  hatch_counter: number,
+  id: number,
+  is_baby: boolean,
+  is_legendary: boolean,
+  is_mythical: boolean,
+  name: string,
+  names: Name[],
+  order: number,
+  pal_park_encounters: PalParkEncounter[],
+  pokedex_numbers: PokedexNumber[],
+  shape: NamedAPIResource,
+  varieties: Variety[]
+}
+
+type Ability = {
+  ability: NamedAPIResource,
+  is_hidden : boolean,
+  slot: number
+}
+
+type Cries = {
+  latest: string,
+  legacy: string | null
+}
+
+type GameIndiceVersion = {
+  game_index: number,
+  version: NamedAPIResource
+}
+
+type VersionDetail = {
+  rarity: number,
+  version: NamedAPIResource
+}
+
+type HeldItem = {
+  item: NamedAPIResource,
+  version_details: VersionDetail[]
+}
+
+type VersionGroupDetail = {
+  level_learned_at: number,
+  move_learn_method: NamedAPIResource,
+  version_group: NamedAPIResource
+}
+
+type Move = {
+  move: NamedAPIResource,
+  version_group_details: VersionGroupDetail[]
+}
+
+type OtherSprites = { 
+  dream_world: {
+    front_default: string,
+    front_female: string | null
+  },
+  home: {
+    front_default: string,
+    front_female: string | null,
+    front_shiny: string,
+    front_shiny_female: string | null
+  },
+  "official-artwork": {
+    front_default: string,
+    front_shiny: string
+  },
+  showdown: {
+    back_default: string,
+    back_female: string | null,
+    back_shiny: string,
+    back_shiny_female: string | null,
+    front_default: string,
+    front_female: string | null,
+    front_shiny: string,
+    front_shiny_female: string | null
+  }
+}
+
+type Sprites = {
+  back_default: string,
+  back_female: string | null,
+  back_shiny: string,
+  back_shiny_female: string | null,
+  front_default: string,
+  front_female: string | null,
+  front_shiny: string,
+  front_shiny_female: string | null,
+  other: OtherSprites,
+  versions: {
+    "generation-i": {
+      "red-blue": {
+        back_default: string | null,
+        back_gray: string | null,
+        back_transparent: string | null,
+        front_default: string | null,
+        front_gray: string | null,
+        front_transparent: string | null
+        },
+      yellow: {
+        back_default: string | null,
+        back_gray: string | null,
+        back_transparent: string | null,
+        front_default: string | null,
+        front_gray: string | null,
+        front_transparent: string | null
+      }
+    },
+    "generation-ii": {
+      crystal: {
+        back_default: string | null,
+        back_shiny: string | null,
+        back_shiny_transparent: string | null,
+        back_transparent: string | null,
+        front_default: string | null,
+        front_shiny: string | null,
+        front_shiny_transparent: string | null,
+        front_transparent: string | null
+        },
+      gold: {
+        back_default: string | null,
+        back_shiny: string | null,
+        front_default: string | null,
+        front_shiny: string | null,
+        front_transparent: string | null
+        },
+      silver: {
+        back_default: string | null,
+        back_shiny: string | null,
+        front_default: string | null,
+        front_shiny: string | null,
+        front_transparent: string | null
+      }
+    },
+    "generation-iii": {
+      emerald: {
+        front_default: string | null,
+        front_shiny: string | null
+      },
+      "firered-leafgreen": {
+        back_default: string | null,
+        back_shiny: string | null,
+        front_default: string | null,
+        front_shiny: string | null
+      },
+      "ruby-sapphire": {
+        back_default: string | null,
+        back_shiny: string | null,
+        front_default: string | null,
+        front_shiny: string | null
+      }
+    },
+    "generation-iv": {
+      "diamond-pearl": {
+        back_default: string | null,
+        back_female: string | null,
+        back_shiny: string | null,
+        back_shiny_female: string | null,
+        front_default: string | null,
+        front_female: string | null,
+        front_shiny: string | null,
+        front_shiny_female: string | null
+      },
+      "heartgold-soulsilver": {
+        back_default: string | null,
+        back_female: string | null,
+        back_shiny: string | null,
+        back_shiny_female: string | null,
+        front_default: string | null,
+        front_female: string | null,
+        front_shiny: string | null,
+        front_shiny_female: string | null
+      },
+      platinum: {
+        back_default: string | null,
+        back_female: string | null,
+        back_shiny: string | null,
+        back_shiny_female: string | null,
+        front_default: string | null,
+        front_female: string | null,
+        front_shiny: string | null,
+        front_shiny_female: string | null
+      }
+    },
+    "generation-v": {
+      "black-white": {
+        animated: {
+          back_default: string | null,
+          back_female: string | null,
+          back_shiny: string | null,
+          back_shiny_female: string | null,
+          front_default: string | null,
+          front_female: string | null,
+          front_shiny: string | null,
+          front_shiny_female: string | null
+        },
+        back_default: string | null,
+        back_female: string | null,
+        back_shiny: string | null,
+        back_shiny_female: string | null,
+        front_default: string | null,
+        front_shiny: string | null,
+        front_shiny_female: string | null
+      }
+    },
+    "generation-vi": {
+      "omegaruby-alphasapphire": {
+        front_default: string | null,
+        front_female: string | null,
+        front_shiny: string | null,
+        front_shiny_female: string | null
+      },
+      "x-y": {
+        front_default: string | null,
+        front_female: string | null,
+        front_shiny: string | null,
+        front_shiny_female: string | null
+      }        
+    },
+    "generation-vii": {
+      icons: {
+        front_default: string | null,
+        front_female: string | null
+      },
+      "ultra-sun-ultra-moon": {
+        "front_default": string | null,
+        "front_female": string | null,
+        "front_shiny": string | null,
+        "front_shiny_female": string | null
+      }
+    },
+    "generation-viii":  {
+      icons: {
+        front_default: string | null,
+        front_female: string | null
+      }
+    }
+ }
+}
+
+type StatDetails = {
+  base_stat: number,
+  effort: number,
+  stat: NamedAPIResource
+}
+
+export type PokemonPage = {
+  abilities: Ability[]
+  base_experience: number,
+  cries: Cries,
+  forms: NamedAPIResource[],
+  game_indices: GameIndiceVersion[],
+  height: number,
+  held_items: HeldItem[]
+  id: number,
+  is_default: boolean,
+  location_area_encounters: string,
+  moves: Move[],
+  name: string,
+  order: number,
+  past_abilities: NamedAPIResource[],
+  past_types: NamedAPIResource[],
+  species: NamedAPIResource,
+  sprites: Sprites,
+  stats: StatDetails[],
+  types: PokemonType[],
+  weight: number
+}
+
+
+type GameIndiceGen = {
+  game_index: number,
+  generation: NamedAPIResource
+}
+
+type TypeRelations = {
+  double_damage_from: NamedAPIResource[],
+  double_damage_to: NamedAPIResource[]
+  half_damage_from: NamedAPIResource[]
+  half_damage_to: NamedAPIResource[]
+  no_damage_from: NamedAPIResource[]
+  no_damage_to: NamedAPIResource[]
+}
+
+type TypePokemon = {
+  pokemon: NamedAPIResource,
+  slot: number
+}
+
+export type PokemonTypePage = {
+  damage_relations: TypeRelations,
+  game_indices: GameIndiceGen[],
+  generation: NamedAPIResource,
+  id: number,
+  move_damage_class: NamedAPIResource | null,
+  moves: NamedAPIResource[],
+  name: string,
+  names: Name[],
+  past_damage_relations: {
+    damage_relations: TypeRelations,
+    generation: NamedAPIResource
+  }[],
+  pokemon: TypePokemon[]
+}


### PR DESCRIPTION
## Description

Optimized caching, improvements made on the caching of the type pokemons endpoint, also some refactoring was done on overall code.

## Images (optional)

None.

## Current behavior

Caching of pokemon from the types endpoint is uncertain, it is also difficult to read code from the "usePokemonsPreviewDataTypes" hook.

## Expected behavior

Caching of pokemons from the types endpoint is certainly correct, it is now much easier to read code from the "usePokemonsPreviewDataTypes" hook.

## Describe changes

- Added new pokemon-related-types, the main ones being: "PokemonPage", "PokemonTypesPage" and "SpeciesPage".
- Moved providers import and use from "App.tsx" to "main.tsx".
- Changed from "useQuery" to "useQueries" hook for fetching data of types endpoint.

## Requirements

- Review the current method of fetching and caching data from the API types endpoint.