### PR TITLE
fixed: removed on push trigger from workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,10 +2,6 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the stable branch
-  push:
-    branches: ['stable']
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

Since github does not allow deploying from other branches than main, there was no point on having a push trigger for the stable branch, and since a on push trigger for the main branch is not on the table, from now on, deploying will be done manually.

## Images (optional)

None.

## Current behavior

Trigger set to a on push action for the stable branch, even though it won't work.

## Expected behavior

Complete remotion of on push trigger for the stable branch, deploying is purely manual now.

## Describe changes

- Altered the "deploy.yml" file.