### PR TITLE
fixed: pokemons sorting in filtered search

### DIFF
--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -23,7 +23,7 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
   }, [])
 
   return { 
-    previewData: res!.length !== 0 ? res! : null, 
+    previewData: res!.length !== 0 ? res!.sort((a, b) => a.id - b.id) : null, 
     isLoading: isLoadingTypes || isLoadingGen
   }
 }


### PR DESCRIPTION
## Description

Pokemons being displayed unordered.

## Images (optional)

None.

## Current behavior

Pokemons are being displayed unordered, it looks odd.

## Expected behavior

Pokemons being displayed in ascending order by id.

## Describe changes

- Added a sort method to the "useFilteredPokemonsPreviewData" hook's return.