### PR TITLE
feature: image preloading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.4.0</title>
+    <title>Really Simple Pokedex V1.5.0</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/PokePaginationBar.tsx
+++ b/src/components/PokePaginationBar.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query"
 
 import { getPokemonData } from "../functions/poke-functions"
+import { preloadImage } from "../hooks/useImagePreloader"
 import { CenteredFlexRow } from "./main-components"
 import { PaginationCell, PaginationCellCurrent } from "./styles"
 
@@ -37,26 +38,34 @@ function PokePaginationBar ({
   }
 
   /*
-    Prefetch up to {growth} of next pages, or nothing
+    Prefetch up to {growth * 2} of next pages, or nothing
     if there is no next page.
   */
-  for (let i = nextPageId; i <= cells[cells.length - 1]; i++) {
+  for (let i = nextPageId; i <= cells[cells.length - 1] + growth; i++) {
     if (current !== cells[cells.length - 1]){   
-      queryClient.prefetchQuery({
+      if (i > max) continue
+
+      queryClient.fetchQuery({
         queryKey: ['pokemonId', i],
         queryFn: async () => await getPokemonData(i)
+      }).then(data => {
+        if (data !== null) preloadImage(data.spriteSrc)
       })
     } 
   }
   /*
-    Prefetch up to {growth} of previous pages, or nothing
+    Prefetch up to {growth * 2} of previous pages, or nothing
     if theere is no previous page.
    */
-  for (let i = previousPageId; i >= cells[0]; i--) {
+  for (let i = previousPageId; i >= cells[0] - growth; i--) {
     if (current !== cells[0]){   
-      queryClient.prefetchQuery({
+      if (i < min) continue
+
+      queryClient.fetchQuery({
         queryKey: ['pokemonId', i],
         queryFn: async () => await getPokemonData(i)
+      }).then(data => {
+        if (data !== null) preloadImage(data.spriteSrc)
       })
     } 
   }

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -2,7 +2,7 @@ import { capitalize } from "../functions/other-functions"
 import { getPokemonTypeColor, getPokemonWrapperTypeColor } from "../functions/poke-functions"
 import { PokemonData } from "../types/pokemon-related-types"
 import { SubTitle, Text, Title } from "./main-components"
-import { PokemonImage, PokemonImageWrapper } from "./main-poke-components"
+import { PokemonSprite, PokemonSpriteWrapper } from "./main-poke-components"
 import PokePaginationBar  from "./PokePaginationBar"
 import { CenteredFlexColGap, PokemonCardWrapper, PokemonEntry, PokemonStatsWrapper, PokemonType, PokemonTypesWrapper } from "./styles"
 
@@ -17,14 +17,16 @@ function PokemonCard({
   pokedexEntries, 
   maxNumberOfPokemons 
 }: PokemonData) {
+
   return (
     <CenteredFlexColGap>
       <PokemonCardWrapper type={getPokemonWrapperTypeColor(types[0])}>
         <PokemonStatsWrapper type={getPokemonTypeColor(types[0])}>
-          <Title color="#fff">{capitalize(name)}#{id}</Title>
-          <PokemonImageWrapper>
-            <PokemonImage src={`${spriteSrc}`} width={250} height={250}/>
-          </PokemonImageWrapper>
+          <Title color="#fff">{capitalize(name)}</Title>
+          <PokemonSpriteWrapper>
+            <PokemonSprite src={`${spriteSrc}`} width={250} height={250}/>
+          </PokemonSpriteWrapper>
+          <SubTitle color="#fff">ID: <Text>{id}</Text></SubTitle>
           <SubTitle color="#fff">Gen: <Text>{gen}</Text></SubTitle>
           <SubTitle color="#fff">Height: <Text>{height}m</Text></SubTitle>
           <SubTitle color="#fff">Weight: <Text>{weight}kg</Text></SubTitle>

--- a/src/components/PokemonPreviewCard.tsx
+++ b/src/components/PokemonPreviewCard.tsx
@@ -3,18 +3,20 @@ import { useEffect, useState } from "react";
 
 import { capitalize } from "../functions/other-functions";
 import { getPokemonData, getPokemonTypeColor } from "../functions/poke-functions";
+import useImagePreloader from "../hooks/useImagePreloader";
 import useOnScreen from "../hooks/useOnScreen";
 import { PokemonData } from "../types/pokemon-related-types";
 import HoverableGrowthFeedback from "./feedbacks/HoverableGrowthFeedback";
 import PokemonPreviewCardLoadingFeedback from "./feedbacks/PokemonPreviewCardLoadingFeedback";
 import { NoDecorationLink, Title } from "./main-components";
-import { PokemonImage, PokemonImageWrapper, PokemonPreviewCardWrapper } from "./main-poke-components";
+import { PokemonPreviewCardWrapper, PokemonSprite, PokemonSpriteWrapper } from "./main-poke-components";
 
 function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
   const queryClient = useQueryClient()
   const { ref, isVisible } = useOnScreen()
-  const [pokemonData, setPokemonData] = useState<PokemonData | null>(null);
-  
+  const [pokemonData, setPokemonData] = useState<PokemonData | null>(null)
+  const { hasLoaded } = useImagePreloader(pokemonData ? pokemonData.spriteSrc : '')
+
   useEffect(() => {
     if (isVisible && pokemonData === null) {
       queryClient.fetchQuery({
@@ -24,7 +26,7 @@ function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
     }
   }, [isVisible]);
 
-  if (pokemonData === null) {
+  if (pokemonData === null || hasLoaded === false) {
     return (
       <PokemonPreviewCardLoadingFeedback ref={ref} name={name} id={id}/>
     )
@@ -38,9 +40,9 @@ function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
       <NoDecorationLink to={`/pokemon/${pokemonData.id}`}>
         <PokemonPreviewCardWrapper ref={ref} type={getPokemonTypeColor(pokemonData.types[0])}>
           <Title color="#fff">{capitalize(pokemonData.name)}</Title>
-          <PokemonImageWrapper>
-            <PokemonImage src={pokemonData.spriteSrc} alt={`Pokemon ${pokemonData.id}`}/>
-          </PokemonImageWrapper>
+          <PokemonSpriteWrapper>
+            <PokemonSprite src={pokemonData.spriteSrc} alt={`Pokemon ${pokemonData.id}`}/>
+          </PokemonSpriteWrapper>
           <Title color="#fff">#{pokemonData.id}</Title>
         </PokemonPreviewCardWrapper>
       </NoDecorationLink>

--- a/src/components/feedbacks/PokemonCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonCardLoadingFeedback.tsx
@@ -1,12 +1,12 @@
+import { PokemonSpriteWrapper } from '../main-poke-components'
 import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
-import { PokemonImageWrapper } from '../main-poke-components'
 
 function PokemonCardLoadingFeedback({ id }: {id: number}) {
   return (
     <div>
-      <PokemonImageWrapper>
+      <PokemonSpriteWrapper>
         <RotatingPokeballFeedback pokemonId={id}/>
-      </PokemonImageWrapper>
+      </PokemonSpriteWrapper>
       <h1>Loading...</h1>
     </div>
   )

--- a/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
@@ -1,8 +1,10 @@
 import { forwardRef } from "react"
-import { PokemonImageWrapper, PokemonPreviewCardWrapper } from "../main-poke-components"
-import { Title } from "../main-components"
-import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
+
 import { capitalize } from "../../functions/other-functions"
+import { NoDecorationLink, Title } from "../main-components"
+import { PokemonPreviewCardWrapper, PokemonSpriteWrapper } from "../main-poke-components"
+import HoverableGrowthFeedback from "./HoverableGrowthFeedback"
+import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
 
 const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement, 
 { 
@@ -11,13 +13,20 @@ const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement,
 }>(
   (props, ref) => {
   return (
-    <PokemonPreviewCardWrapper ref={ref}>
-      <Title color="#fff">{capitalize(props.name)}</Title>
-      <PokemonImageWrapper>
-        <RotatingPokeballFeedback pokemonId={props.id}/>
-      </PokemonImageWrapper>
-      <Title color="#fff">Loading...</Title>
-    </PokemonPreviewCardWrapper>
+    <HoverableGrowthFeedback
+      borderBottomRightRadius={16} 
+      borderTopLeftRadius={16}
+    >
+      <NoDecorationLink to={`/pokemon/${props.id}`}>
+        <PokemonPreviewCardWrapper ref={ref}>
+          <Title color="#fff">{capitalize(props.name)}</Title>
+          <PokemonSpriteWrapper>
+            <RotatingPokeballFeedback pokemonId={props.id}/>
+          </PokemonSpriteWrapper>
+          <Title color="#fff">Loading...</Title>
+        </PokemonPreviewCardWrapper>
+      </NoDecorationLink>
+    </HoverableGrowthFeedback>
   )
 })
 

--- a/src/components/main-poke-components.ts
+++ b/src/components/main-poke-components.ts
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import { CenteredFlexCol } from "./main-components";
+
 import { POKEMON_IMAGE_WRAPPER_BG_COLOR } from "../constants/pokemon-related-constants";
+import { CenteredFlexCol } from "./main-components";
 
 export const PokemonPreviewCardWrapper = styled(CenteredFlexCol)<{ type?: string }>`
   text-wrap: balance;
@@ -10,13 +11,13 @@ export const PokemonPreviewCardWrapper = styled(CenteredFlexCol)<{ type?: string
   gap: 1.5rem;
   padding: 1.5rem;
 `
-export const PokemonImageWrapper = styled(CenteredFlexCol)`
+export const PokemonSpriteWrapper = styled(CenteredFlexCol)`
   border-radius: 100000px;
   background-color: ${POKEMON_IMAGE_WRAPPER_BG_COLOR};
   height: 250px;
   width: 250px;
 `
-export const PokemonImage = styled.img`
+export const PokemonSprite = styled.img`
   width: auto;
   height: auto;
   max-width: 200px;

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -62,7 +62,7 @@ export const CenteredFlexColGap = styled(CenteredFlexCol)`
   gap: 3rem;
 `
 export const PokemonStatsWrapper = styled(CenteredFlexCol)<{ type?: string}>`
-  justify-content: start;
+  min-width: 325px;
   border-top-left-radius: 1rem;
   background-color: ${(props) => props.type ? props.type : '#d4d4d4'};
   padding: 1.5rem;

--- a/src/functions/testing.test.ts
+++ b/src/functions/testing.test.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@jest/globals'
 
-
 test('testing', async () => {
-  let arr: number[] = new Array(3)
-
-  expect(arr).toStrictEqual([0,0,0])
+  const arr = 'something'
+  expect(Array.isArray(arr)).toBe(false)
 })

--- a/src/hooks/useImagePreloader.ts
+++ b/src/hooks/useImagePreloader.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react"
+
+export function preloadImage(src: string) {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.src = src
+
+    img.onload = () => resolve(img)
+    img.onabort = () => reject(img)
+    img.onerror = () => reject(img)
+  })
+}
+
+function useImagePreloader(src: string[] | string) {
+  const [hasLoaded, setHasLoaded] = useState(false)
+
+  useEffect(() => {
+    preload()
+    
+    async function preload() {
+      if (Array.isArray(src)) { // a string[]
+        for (const imageSrc of src) {
+          await preloadImage(imageSrc)
+        }
+        
+        setHasLoaded(true)
+      } else { // just 1 src string
+        await preloadImage(src)
+
+        setHasLoaded(true)
+      }
+    }
+
+    return () => setHasLoaded(false)
+  }, [src])
+
+  return { hasLoaded }
+}
+
+export default useImagePreloader

--- a/src/hooks/useOnScreen.ts
+++ b/src/hooks/useOnScreen.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 function useOnScreen() {
   const [element, setElement] = useState<Element | null>(null);
@@ -12,7 +12,7 @@ function useOnScreen() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(      
-      ([entry]) => setIsVisible(entry.isIntersecting), { rootMargin: '700px'})
+      ([entry]) => setIsVisible(entry.isIntersecting), { rootMargin: '1400px'})
 
     const currentElement = element
 

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -1,7 +1,8 @@
 import { useParams } from "react-router-dom"
-import useSinglePokemonData from "../hooks/useSinglePokemonData"
-import PokemonCard from "../components/PokemonCard"
+
 import PokemonCardLoadingFeedback from "../components/feedbacks/PokemonCardLoadingFeedback"
+import PokemonCard from "../components/PokemonCard"
+import useSinglePokemonData from "../hooks/useSinglePokemonData"
 
 // TODO: styling
 
@@ -9,7 +10,7 @@ function SinglePokemon() {
   const { id } = useParams()
   const pokemonId = Number(id)
   const { data, isLoading } = useSinglePokemonData(pokemonId)
-    
+  
   if (isLoading) return <PokemonCardLoadingFeedback id={pokemonId}/>
   else if (data === null) return <h1>Sorry, no pokemon found with this id.</h1>
     


### PR DESCRIPTION
## Description

It is difficult to check for pokemon sprites loading status, resulting on pokemon sprites loading even when they were supposed to be completely loaded.

## Images (optional)

None.

## Current behavior

Pokemon sprites not being displayed immediately after data is displayed, pokemon sprites or previous pokemon sprites (in case of single pokemon pages)  being displayed.

## Expected behavior

Pokemon sprites being displayed immediately after data is displayed, no pokemon sprites loading or previous pokemon sprites (in case of single pokemon pages)  being displayed.

## Describe changes

- Added a "useImagePreloader" hook to preload and check for image loading status.
- Added a "preloadImage" function to preload images.

## Requirements

- Altered how preloading woks on single pokemon pages, now preloading is done up to double the number of pages for next and previous pages, it will preload pages that are still not even on the pagination bar. 