### PR TITLE
feature: added ui for filtered search

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.5.0</title>
+    <title>Really Simple Pokedex V1.6.0</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import { Routes, Route } from "react-router-dom"
-import Home from "./pages/Home"
-import SinglePokemon from "./pages/SinglePokemon"
-import Redirect from "./pages/Redirect"
+import { Route, Routes } from "react-router-dom"
+
 import NavigationHeader from "./components/NavigationHeader"
 import Filtered from "./pages/Filtered"
-
+import Home from "./pages/Home"
+import Redirect from "./pages/Redirect"
+import SinglePokemon from "./pages/SinglePokemon"
 
 function App() {
   return (

--- a/src/components/ArrayToJSXTransformer.tsx
+++ b/src/components/ArrayToJSXTransformer.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react"
+
+function ArrayToJSXTransformer<T>(
+{ 
+  dataArray, 
+  transformer
+}: { 
+  dataArray: T[], 
+  transformer: (elementData: T) => ReactNode,
+}) {
+  const transformed = dataArray.map((some) => transformer(some))
+
+  return (
+    <>
+      {transformed}
+    </>
+  )
+}
+
+export default ArrayToJSXTransformer

--- a/src/components/FilteringOptionsUI.tsx
+++ b/src/components/FilteringOptionsUI.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom"
+
+import { VALID_GENS, VALID_TYPES } from "../constants/pokemon-related-constants";
+import { sanitizeTypes } from "../functions/poke-functions";
+import useURLSearchParams from "../hooks/useURLSearchParams";
+import ArrayToJSXTransformer from "./ArrayToJSXTransformer";
+import { CenteredFlexCol } from "./main-components";
+import { CenteredFlexColGap, CenteredFlexRowGap, FeedbackedButton, Filter, FilterType, FiltersWrapper } from "./styles";
+
+function FilteringOptionsUI() {
+  const searchParams = useURLSearchParams()
+  const types = sanitizeTypes([searchParams.type1, searchParams.type2])
+  const gen = searchParams.gen
+  const [filters, setFilters] = useState<{name: string, type: string}[]>(
+    [
+      {name: types[0], type: 'type'}, 
+      {name: types[1], type: 'type'}, 
+      {name: `${gen}`, type: 'gen'}
+    ].filter(item => item.name)
+  )
+  
+  const navigate = useNavigate()
+
+  return (
+    <CenteredFlexColGap>
+      <CenteredFlexColGap>
+        <CenteredFlexCol>
+          <h1>Gens</h1>
+          <FiltersWrapper>
+            <ArrayToJSXTransformer
+              dataArray={VALID_GENS}
+              transformer={(gen) => {
+                return (
+                  <Filter 
+                    onClick={() => {
+                      const activeGens = filters.filter(item => item.type === 'gen') 
+                      
+                      if (activeGens.length < 1) {
+                        setFilters(prev => [...prev, {name: `${gen}`, type: 'gen'}])}  
+                      }
+                    }
+                    key={`filter-gen-${gen}`}
+                  >
+                    { `Gen ${gen}` }
+                  </Filter>
+                )
+              }}
+            />
+          </FiltersWrapper>
+        </CenteredFlexCol> 
+        <CenteredFlexCol>
+          <h1>Types</h1>
+          <FiltersWrapper>
+            <ArrayToJSXTransformer
+              dataArray={VALID_TYPES}
+              transformer={(type) => {
+                return (
+                  <FilterType 
+                    type={type} 
+                    onClick={() => {
+                      const activeTypes = filters.filter(item => item.type === 'type')
+                      
+                      if (activeTypes.length < 2 && !activeTypes.find(item => item.name === type)) {
+                        setFilters(prev => [...prev, {name: `${type}`, type: 'type'}])}  
+                      }
+                    }
+                    key={`filter-type-${type}`}
+                  >
+                    { type }
+                  </FilterType>
+                )
+              }}
+            />
+          </FiltersWrapper>
+        </CenteredFlexCol>
+      </CenteredFlexColGap>
+      <CenteredFlexCol> 
+        <h1 hidden={filters.length === 0}>Filters</h1>
+        <FiltersWrapper>
+          <ArrayToJSXTransformer
+            dataArray={filters}
+            transformer={(active) => {
+              return active.type === 'type' ? (
+                <FilterType type={active.name} key={`option-${active.type}-${active.name}`} onClick={() => setFilters(prev => prev.filter(item => item !== active))}>
+                  {active.name} 
+                </FilterType>
+              ) : (
+                <Filter key={`option-${active.type}-${active.name}`} onClick={() => setFilters(prev => prev.filter(item => item !== active))}>
+                  {`Gen ${active.name}`} 
+                </Filter>
+              )
+            }}
+          />
+        </FiltersWrapper>
+      </CenteredFlexCol>
+      <CenteredFlexRowGap>
+        <FeedbackedButton hidden={filters.length === 0} onClick={navigateHandler}>Search</FeedbackedButton>
+        <FeedbackedButton hidden={filters.length === 0} onClick={() => setFilters([])} >Reset</FeedbackedButton>
+      </CenteredFlexRowGap>
+    </CenteredFlexColGap>
+  )
+
+  function navigateHandler() {
+    let navlink = ['/filtered?']
+    const gen = filters.find(item => item.type === 'gen')
+    const activeTypes = filters.filter(item => item.type === 'type')
+
+    if (gen) {
+      navlink.push(`gen=${gen.name}`)
+    }
+    activeTypes.forEach((item, index) => {
+      if (item) navlink.push(`type${index + 1}=${item.name}`)
+    })
+
+    if (navlink.length !== 1) navigate(navlink.join('&'))
+
+  }
+}
+
+export default FilteringOptionsUI

--- a/src/components/feedbacks/HoverableGrowthFeedback.tsx
+++ b/src/components/feedbacks/HoverableGrowthFeedback.tsx
@@ -27,12 +27,13 @@ function HoverableGrowthFeedback({
 }) {
   return (
     <GrowOnHover 
-      style={{
-        borderRadius: borderRadius ?? 0,
-        borderBottomRightRadius: borderBottomRightRadius ?? 0,
-        borderBottomLeftRadius: borderBottomLeftRadius ?? 0,
-        borderTopRightRadius: borderTopRightRadius ?? 0,
-        borderTopLeftRadius: borderTopLeftRadius ?? 0
+    style={borderRadius ? {
+        borderRadius: borderRadius ?? 'initial',
+      } : {
+        borderBottomRightRadius: borderBottomRightRadius ?? 'initial',
+        borderBottomLeftRadius: borderBottomLeftRadius ?? 'initial',
+        borderTopRightRadius: borderTopRightRadius ?? 'initial',
+        borderTopLeftRadius: borderTopLeftRadius ?? 'initial'
       }}
     >
       { children }

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -1,6 +1,8 @@
+import { ReactNode } from "react"
 import styled from "styled-components"
 
 import { getPokemonTypeColor } from "../functions/poke-functions"
+import HoverableGrowthFeedback from "./feedbacks/HoverableGrowthFeedback"
 import { CenteredFlexCol, CenteredFlexRow, NoDecorationLink, Title } from "./main-components"
 
 export const PaginationCell = styled(NoDecorationLink)`
@@ -113,3 +115,73 @@ export function PokemonType({ type }: { type: string }) {
     </PokemonTypeWrapper>
   )
 }
+
+const FilterBase = styled(CenteredFlexRow)`
+  border-radius: 4rem;
+  background-color: gray;
+  min-width: 5rem;
+  cursor: pointer;
+  padding: 1rem;
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: bold;
+`
+
+export const FiltersWrapper = styled(CenteredFlexRow)`
+  flex-wrap: wrap;
+  gap: 1rem;
+`
+export function Filter({ 
+  children, 
+  onClick
+}: { 
+  children: ReactNode, 
+  onClick: () => void
+}) {
+  return (
+    <HoverableGrowthFeedback
+      borderRadius={64}
+    >
+      <FilterBase onClick={onClick}>
+        { children }
+      </FilterBase>
+    </HoverableGrowthFeedback>
+  )
+}
+
+export function FilterType({ 
+  children, 
+  type, 
+  onClick 
+}: { 
+  children: ReactNode, 
+  type: string, 
+  onClick: () => void 
+}) {
+  return (
+    <HoverableGrowthFeedback
+      borderRadius={64}
+    >
+      <FilterBase onClick={onClick} style={{ backgroundColor: getPokemonTypeColor(type), minWidth: '8rem' }}>
+        { children }
+      </FilterBase>
+    </HoverableGrowthFeedback>
+  )
+} 
+
+
+export const FeedbackedButton = styled.button`
+  transition: 0.3s;
+  border-radius: 4rem;
+  background-color: #1d4ede;
+  cursor: pointer;
+  padding: 1rem 5rem;
+  color: #fff;
+  font-size: 2rem;
+  font-weight: bold;
+
+  &: hover {
+    transform: scale(1.2);
+    background-color: #215aff;
+  }
+`

--- a/src/constants/pokemon-related-constants.ts
+++ b/src/constants/pokemon-related-constants.ts
@@ -1,1 +1,13 @@
 export const POKEMON_IMAGE_WRAPPER_BG_COLOR = '#ffe294' 
+export const VALID_TYPES = [
+  'normal', 'fighting', 
+  'flying', 'poison', 
+  'ground', 'rock', 
+  'bug', 'ghost',
+  'steel', 'fire',
+  'water', 'grass',
+  'electric', 'psychic',
+  'ice', 'dragon',
+  'dark', 'fairy'
+]
+export const VALID_GENS = [1,2,3,4,5,6,7,8,9]

--- a/src/functions/other-functions.ts
+++ b/src/functions/other-functions.ts
@@ -47,12 +47,12 @@ function getCommonItemsFromObjectArrays(
   propertyKey: string
 ): any[]{
   for (const obj of arr1) {
-    if (obj.hasOwnProperty(propertyKey) === false || isPropertyOfTypeString(obj, propertyKey) === false) {
+    if (obj.hasOwnProperty(propertyKey) === false || (isPropertyOfTypeString(obj, propertyKey) === false && isPropertyANaturalNumber(obj, propertyKey) === false)) {
       return []
     }
   }
   for (const obj of arr2) {
-    if (obj.hasOwnProperty(propertyKey) === false || isPropertyOfTypeString(obj, propertyKey) === false) {
+    if (obj.hasOwnProperty(propertyKey) === false || (isPropertyOfTypeString(obj, propertyKey) === false && isPropertyANaturalNumber(obj, propertyKey) === false)) {
       return []
     }
   }
@@ -73,6 +73,9 @@ function getCommonItemsFromObjectArrays(
  */
 function isPropertyOfTypeString(obj: any, propertyKey: string) {
   return typeof obj[propertyKey] === 'string'
+}
+function isPropertyANaturalNumber(obj: any, propertyKey: string) {
+  return typeof obj[propertyKey] === 'number' && isNaturalNumber(obj[propertyKey])
 }
 /**
  * Checks if a certain object is an empty object, that is 

--- a/src/functions/poke-functions.ts
+++ b/src/functions/poke-functions.ts
@@ -1,3 +1,4 @@
+import { VALID_GENS, VALID_TYPES } from "../constants/pokemon-related-constants";
 import {
   NamedAPIResource,
   NamedAPIResourceList,
@@ -11,7 +12,7 @@ import { isInRange, isNaturalNumber } from "./other-functions";
 export async function getPokemonData(id: number): Promise<PokemonData | null> {
   const maxNumberOfPokemons = await getMaxNumberOfPokemons()
 
-  if (!isNaturalNumber(id) || !isInRange(id, maxNumberOfPokemons)) return null
+  if (await isValidPokemonId(id) === false) return null
 
   const resPokemonPageData = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`)
   const rawPokemonPageData: PokemonPage = await resPokemonPageData.json()
@@ -42,8 +43,8 @@ export async function getPokemonData(id: number): Promise<PokemonData | null> {
 
 function getGenFromFetchedData(fetchedPokemonSpeciesData: SpeciesPage) {
   const genURL = fetchedPokemonSpeciesData.generation.url
-  
-  return Number(genURL[genURL.length - 2])
+    
+  return Number(genURL.split('/')[6])
 }
 
 export async function getMaxNumberOfPokemons(): Promise<number> {
@@ -90,26 +91,33 @@ export function getGenRegion(gen: number) {
 }
 
 export function sanitizeTypes(types: string[]) {
-  const validTypes = [
-    'normal', 'fighting', 
-    'flying', 'poison', 
-    'ground', 'rock', 
-    'bug', 'ghost',
-    'steel', 'fire',
-    'water', 'grass',
-    'electric', 'psychic',
-    'ice', 'dragon',
-    'dark', 'fairy'
-  ]
   let sanitizedTypes: string[] = []
 
   for (const type of types) {
-    if (validTypes.includes(type)) {
+    if (VALID_TYPES.includes(type)) {
       sanitizedTypes.push(type)
     }
   }
 
   return sanitizedTypes
+}
+
+export function isValidType(type: string) {
+  return VALID_TYPES.includes(type)
+}
+
+export function isValidGen(gen: number) {
+  return isNaturalNumber(gen) && isInRange(gen, VALID_GENS.length)
+}
+
+export async function isValidPokemonId(id: number) {
+  const maxPokemons = await getMaxNumberOfPokemons()
+  
+  return isNaturalNumber(id) && isInRange(id, maxPokemons)
+}
+
+export function getSortedPokemonsById(pokemons: PokemonPreviewData[] | PokemonData[]) {
+  return [...pokemons].sort((a, b) => a.id - b.id)
 }
 
 export function getPokemonTypeColor(type: string): string {

--- a/src/functions/poke-functions.ts
+++ b/src/functions/poke-functions.ts
@@ -60,7 +60,7 @@ export function getPokemonPreviewDataFromArray(arr: NamedAPIResource[]): Pokemon
   }))
 }
 
-export function removeNonPokemonSpeciesObjectsFromArray(arr: PokemonPreviewData[]): PokemonPreviewData[] {
+export function removeNonSpeciesFromArray(arr: PokemonPreviewData[]): PokemonPreviewData[] {
   return arr.filter(item => item.id < 10000)
 }
 

--- a/src/functions/testing.test.ts
+++ b/src/functions/testing.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 
 test('testing', async () => {
-  const arr = 'something'
-  expect(Array.isArray(arr)).toBe(false)
+  const arr = ['something', 'something-else']
+  expect(arr.join('&')).toBe('something&something-else')
 })

--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -1,9 +1,24 @@
-import { getCommonItemsFromObjectArrays, isObjectEmpty } from "../functions/other-functions";
-import { PokemonFilteringOptions, PokemonsPreviewDataStatus } from "../types/pokemon-related-types";
+import {
+  getCommonItemsFromObjectArrays,
+  isObjectEmpty
+} from "../functions/other-functions";
+import {
+  PokemonFilteringOptions,
+  PokemonsPreviewDataStatus
+} from "../types/pokemon-related-types";
 import usePokemonsPreviewDataGen from "./usePokemonsPreviewDataGen";
 import usePokemonsPreviewDataTypes from "./usePokemonsPreviewDataTypes";
 
 function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): PokemonsPreviewDataStatus {
+  const { 
+    isLoading: isLoadingGen, 
+    previewData: previewDataGen 
+  } = usePokemonsPreviewDataGen(Number(options.gen))
+  const { 
+    isLoading: isLoadingTypes, 
+    previewData: previewDataTypes 
+  } = usePokemonsPreviewDataTypes(options.types ?? [])
+
   if (isObjectEmpty(options)) {
     return {
       previewData: null,
@@ -11,19 +26,16 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
     }
   }
 
-  const { isLoading: isLoadingGen, previewData: previewDataGen } = usePokemonsPreviewDataGen(Number(options.gen))
-  const { isLoading: isLoadingTypes, previewData: previewDataTypes } = usePokemonsPreviewDataTypes(options.types ?? [])
-
   const sanitized = [previewDataGen, previewDataTypes].filter(item => item !== null)
 
-  const res = sanitized.reduce((prev, curr, index) => {
+  const reducedData = sanitized.reduce((prev, curr, index) => {
     if (index === 0) return curr
 
     return getCommonItemsFromObjectArrays(prev!, curr!, 'name')
   }, [])
 
   return { 
-    previewData: res!.length !== 0 ? res!.sort((a, b) => a.id - b.id) : null, 
+    previewData: reducedData!.length !== 0 ? reducedData!.sort((a, b) => a.id - b.id) : null, 
     isLoading: isLoadingTypes || isLoadingGen
   }
 }

--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -2,6 +2,7 @@ import {
   getCommonItemsFromObjectArrays,
   isObjectEmpty
 } from "../functions/other-functions";
+import { getSortedPokemonsById } from "../functions/poke-functions";
 import {
   PokemonFilteringOptions,
   PokemonsPreviewDataStatus
@@ -29,13 +30,13 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
   const sanitized = [previewDataGen, previewDataTypes].filter(item => item !== null)
 
   const reducedData = sanitized.reduce((prev, curr, index) => {
-    if (index === 0) return curr
+    if (index === 0) return curr!
 
-    return getCommonItemsFromObjectArrays(prev!, curr!, 'name')
+    return getCommonItemsFromObjectArrays(prev!, curr!, 'id')
   }, [])
 
   return { 
-    previewData: reducedData!.length !== 0 ? reducedData!.sort((a, b) => a.id - b.id) : null, 
+    previewData: reducedData!.length !== 0 ? getSortedPokemonsById(reducedData!) : null, 
     isLoading: isLoadingTypes || isLoadingGen
   }
 }

--- a/src/hooks/useImagePreloader.ts
+++ b/src/hooks/useImagePreloader.ts
@@ -18,17 +18,20 @@ function useImagePreloader(src: string[] | string) {
     preload()
     
     async function preload() {
-      if (Array.isArray(src)) { // a string[]
-        for (const imageSrc of src) {
-          await preloadImage(imageSrc)
-        }
-        
-        setHasLoaded(true)
-      } else { // just 1 src string
-        await preloadImage(src)
+      try {
 
-        setHasLoaded(true)
-      }
+        if (Array.isArray(src)) { // a string[]
+          for (const imageSrc of src) {
+            await preloadImage(imageSrc)
+          }
+          
+          setHasLoaded(true)
+        } else { // just 1 src string
+          await preloadImage(src)
+          
+          setHasLoaded(true)
+        }
+      } catch (e) {}
     }
 
     return () => setHasLoaded(false)

--- a/src/hooks/usePokemonsPreviewDataGen.ts
+++ b/src/hooks/usePokemonsPreviewDataGen.ts
@@ -1,31 +1,28 @@
 import { useQuery } from "@tanstack/react-query"
+
 import { isInRange, isNaturalNumber } from "../functions/other-functions"
-import { GenPage, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
 import { getPokemonPreviewDataFromArray } from "../functions/poke-functions"
+import { GenPage, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
 
 function usePokemonsPreviewDataGen(gen: number): PokemonsPreviewDataStatus {
-  // Param handling
-  if (isNaturalNumber(gen) === false && isInRange(gen, 9) === false) return ({
-    previewData: null,
-    isLoading: false
-  })
-
   const { data, isLoading } = useQuery({
     queryKey: ['pokemonGen', gen],
-    queryFn: async () => await getPokemonsPreviewDataFromGen(gen)
+    queryFn: async () => {
+      if (isNaturalNumber(gen) === false || isInRange(gen, 9) === false) {
+        return null
+      }
+      
+      const res = await fetch(`https://pokeapi.co/api/v2/generation/${gen}`)
+      const rawData: GenPage = await res.json()
+  
+      return getPokemonPreviewDataFromArray(rawData.pokemon_species)
+    }
   })
 
   return ({
     previewData: data ? data : null,
     isLoading
   })
-
-  async function getPokemonsPreviewDataFromGen(gen: number) {
-    const res = await fetch(`https://pokeapi.co/api/v2/generation/${gen}`)
-    const rawData: GenPage = await res.json()
-
-    return getPokemonPreviewDataFromArray(rawData.pokemon_species)
-  }
 }
 
 export default usePokemonsPreviewDataGen

--- a/src/hooks/usePokemonsPreviewDataTypes.ts
+++ b/src/hooks/usePokemonsPreviewDataTypes.ts
@@ -1,23 +1,41 @@
 import { useQueries } from "@tanstack/react-query"
-import { getCommonItemsFromObjectArrays } from "../functions/other-functions"
-import { NamedAPIResource, NamedAPIResourceList, PokemonPreviewData, PokemonTypePage, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
-import { sanitizeTypes, getPokemonPreviewDataFromArray, removeNonPokemonSpeciesObjectsFromArray } from "../functions/poke-functions"
 import { useMemo } from "react"
 
+import { getCommonItemsFromObjectArrays } from "../functions/other-functions"
+import {
+  getPokemonPreviewDataFromArray,
+  removeNonSpeciesFromArray,
+  sanitizeTypes
+} from "../functions/poke-functions"
+import {
+  NamedAPIResource,
+  NamedAPIResourceList,
+  PokemonTypePage,
+  PokemonsPreviewDataStatus
+} from "../types/pokemon-related-types"
+
 function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus {
-  const pokemonTypes = sanitizeTypes(types) 
-  
-  if (pokemonTypes.length === 0) {
-    return ({
-      previewData: null,
-      isLoading: false
-    })
-  } 
-  
+  const pokemonTypes = useMemo(() => sanitizeTypes(types), [types]) 
+
   const results = useQueries({
     queries: pokemonTypes.map(type => ({
       queryKey: ['pokemonType', type],
-      queryFn: async () => await getPokemonsPreviewDataFromType(type)
+      queryFn: async () => {
+        const res = await fetch(`https://pokeapi.co/api/v2/type`)
+        const rawData: NamedAPIResourceList = await res.json()
+        
+        const typeObjs = rawData.results
+        const typeFetch = typeObjs.find(typeObj => typeObj.name === type)!
+      
+        const resType = await fetch(typeFetch.url)
+        const rawDataType: PokemonTypePage = await resType.json()
+        
+        const pokemonsSrc: NamedAPIResource[] = rawDataType.pokemon.map(
+          pokemonAndSlot => pokemonAndSlot.pokemon
+        )
+
+        return getPokemonPreviewDataFromArray(pokemonsSrc)
+      }
     }))
   })
 
@@ -28,32 +46,16 @@ function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus
     isLoading: results.some(result => result.isLoading)
   }), [results])
 
-  const combinedData = data.reduce((prev, curr, index) => {
+  const reducedData = data.reduce((prev, curr, index) => {
     if (index === 0) return curr
     
     return getCommonItemsFromObjectArrays(prev!, curr!, 'name')
   }, [])
 
   return ({
-    previewData: combinedData!.length !== 0 ? removeNonPokemonSpeciesObjectsFromArray(combinedData!) : null,
+    previewData: reducedData!.length !== 0 ? removeNonSpeciesFromArray(reducedData!) : null,
     isLoading
   })
-  async function getPokemonsPreviewDataFromType(type: string): Promise<PokemonPreviewData[]> {
-    const res = await fetch(`https://pokeapi.co/api/v2/type`)
-    const rawData: NamedAPIResourceList = await res.json()
-    
-    const typeObjs = rawData.results
-    const typeFetch = typeObjs.find(typeObj => typeObj.name === type)!
-  
-    const resType = await fetch(typeFetch.url)
-    const rawDataType: PokemonTypePage = await resType.json()
-    
-    const pokemonsSrc: NamedAPIResource[] = rawDataType.pokemon.map(
-      pokemonAndSlot => pokemonAndSlot.pokemon
-    )
-
-    return getPokemonPreviewDataFromArray(pokemonsSrc)
-  }
 }
 
 export default usePokemonsPreviewDataTypes

--- a/src/hooks/usePokemonsPreviewDataTypes.ts
+++ b/src/hooks/usePokemonsPreviewDataTypes.ts
@@ -4,8 +4,7 @@ import { useMemo } from "react"
 import { getCommonItemsFromObjectArrays } from "../functions/other-functions"
 import {
   getPokemonPreviewDataFromArray,
-  removeNonSpeciesFromArray,
-  sanitizeTypes
+  removeNonSpeciesFromArray
 } from "../functions/poke-functions"
 import {
   NamedAPIResource,
@@ -15,10 +14,8 @@ import {
 } from "../types/pokemon-related-types"
 
 function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus {
-  const pokemonTypes = useMemo(() => sanitizeTypes(types), [types]) 
-
   const results = useQueries({
-    queries: pokemonTypes.map(type => ({
+    queries: types.map(type => ({
       queryKey: ['pokemonType', type],
       queryFn: async () => {
         const res = await fetch(`https://pokeapi.co/api/v2/type`)
@@ -40,14 +37,14 @@ function usePokemonsPreviewDataTypes(types: string[]): PokemonsPreviewDataStatus
   })
 
   const { data, isLoading } = useMemo(() => ({
-    data: results.map(result => result.data ? result.data : null).filter(
+    data: results.map(result => result.data ?? null).filter(
       item => item !== null // weird typescript bug (I think), even though I filtered the array so that there could be no null value, it still says there could be null values on the array which is absurd
     ),
     isLoading: results.some(result => result.isLoading)
   }), [results])
 
   const reducedData = data.reduce((prev, curr, index) => {
-    if (index === 0) return curr
+    if (index === 0) return curr!
     
     return getCommonItemsFromObjectArrays(prev!, curr!, 'name')
   }, [])

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@ body {
 * {
   margin: 0;
   padding: 0;
+  border: 0;
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 

--- a/src/pages/Filtered.tsx
+++ b/src/pages/Filtered.tsx
@@ -1,8 +1,23 @@
+import { useNavigate } from "react-router-dom"
+
+import PokemonPreviewCard from "../components/PokemonPreviewCard"
 import useFilteredPokemonsPreviewData from "../hooks/useFilteredPokemonsPreviewData"
 import useURLSearchParams from "../hooks/useURLSearchParams"
-import PokemonPreviewCard from "../components/PokemonPreviewCard"
 
 function Filtered() {
+  const validTypes = [
+    'normal', 'fighting', 
+    'flying', 'poison', 
+    'ground', 'rock', 
+    'bug', 'ghost',
+    'steel', 'fire',
+    'water', 'grass',
+    'electric', 'psychic',
+    'ice', 'dragon',
+    'dark', 'fairy'
+  ]
+  const validGens = [1,2,3,4,5,6,7,8,9]
+  const navigate = useNavigate()
   const searchParams = useURLSearchParams()
   const { previewData, isLoading } = useFilteredPokemonsPreviewData({
     gen: Number(searchParams.gen),
@@ -17,14 +32,60 @@ function Filtered() {
 
   return (
     <>
+      <div>
+        <label htmlFor="type1">Type 1:</label>
+        <select id="type1">
+          <option value="none">---</option>
+          {validTypes.map(type => (
+            <option key={`type1-option-${type}`} value={type}>{type}</option>)
+          )}
+        </select>
+        <label htmlFor="type2">Type 2:</label>
+        <select id="type2">
+          <option value="none">---</option>
+          {validTypes.map(type => (
+            <option key={`type2-option-${type}`} value={type}>{type}</option>)
+          )}
+        </select>
+        <label htmlFor="gen">Gen:</label>
+        <select id="gen">
+          <option value="none">---</option>
+          {validGens.map(gen => (
+            <option key={`gen-option-${gen}`} value={gen}>{gen}</option>)
+          )}
+        </select>
+        <button onClick={() => {
+          const type1Select: HTMLSelectElement | null = document.querySelector('#type1')
+          const type2Select: HTMLSelectElement | null = document.querySelector('#type2')
+          const genSelect: HTMLSelectElement | null = document.querySelector('#gen')
+
+          const type1Value = type1Select!.value
+          const type2Value = type2Select!.value
+          const genValue = genSelect!.value
+          let navlink = ['/filtered?']
+
+          if (genValue !== 'none') {
+            navlink.push(`gen=${genValue}`)
+          } 
+          if (type1Value !== 'none') {
+            navlink.push(`type1=${type1Value}`)
+          }
+          if (type2Value !== 'none') {
+            navlink.push(`type2=${type2Value}`)
+          }
+
+          if (navlink.length !== 1) navigate(navlink.join('&'))
+
+        }}>search</button>
+      </div>
       <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
-      {previewData.map(fetchedPokemon => (
-        <PokemonPreviewCard 
-          id={fetchedPokemon.id}
-          name={fetchedPokemon.name}
-          key={`pokemon-${fetchedPokemon.id}`}
-        />
-      ))}
+        {previewData.map(fetchedPokemon => (
+          <PokemonPreviewCard 
+            id={fetchedPokemon.id}
+            name={fetchedPokemon.name}
+            key={`pokemon-${fetchedPokemon.id}`}
+          />
+        ))}
       </div>
     </>
   )

--- a/src/pages/Filtered.tsx
+++ b/src/pages/Filtered.tsx
@@ -1,27 +1,16 @@
-import { useNavigate } from "react-router-dom"
-
+import ArrayToJSXTransformer from "../components/ArrayToJSXTransformer"
+import FilteringOptionsUI from "../components/FilteringOptionsUI"
 import PokemonPreviewCard from "../components/PokemonPreviewCard"
+import { CenteredFlexColGap } from "../components/styles"
+import { sanitizeTypes } from "../functions/poke-functions"
 import useFilteredPokemonsPreviewData from "../hooks/useFilteredPokemonsPreviewData"
 import useURLSearchParams from "../hooks/useURLSearchParams"
 
 function Filtered() {
-  const validTypes = [
-    'normal', 'fighting', 
-    'flying', 'poison', 
-    'ground', 'rock', 
-    'bug', 'ghost',
-    'steel', 'fire',
-    'water', 'grass',
-    'electric', 'psychic',
-    'ice', 'dragon',
-    'dark', 'fairy'
-  ]
-  const validGens = [1,2,3,4,5,6,7,8,9]
-  const navigate = useNavigate()
   const searchParams = useURLSearchParams()
   const { previewData, isLoading } = useFilteredPokemonsPreviewData({
     gen: Number(searchParams.gen),
-    types: [searchParams.type1, searchParams.type2]
+    types: sanitizeTypes([searchParams.type1, searchParams.type2])
   }) 
 
   if (isLoading) {
@@ -31,63 +20,21 @@ function Filtered() {
   }
 
   return (
-    <>
-      <div>
-        <label htmlFor="type1">Type 1:</label>
-        <select id="type1">
-          <option value="none">---</option>
-          {validTypes.map(type => (
-            <option key={`type1-option-${type}`} value={type}>{type}</option>)
+    <CenteredFlexColGap>
+      <FilteringOptionsUI/>
+      <div style={{display: "flex", flexDirection: 'row', flexFlow: 'wrap', gap: 16}}>
+        <ArrayToJSXTransformer
+          dataArray={previewData}
+          transformer={(pokemon) => (
+            <PokemonPreviewCard 
+              id={pokemon.id} 
+              name={pokemon.name} 
+              key={`pokemon-${pokemon.id}`}
+            />
           )}
-        </select>
-        <label htmlFor="type2">Type 2:</label>
-        <select id="type2">
-          <option value="none">---</option>
-          {validTypes.map(type => (
-            <option key={`type2-option-${type}`} value={type}>{type}</option>)
-          )}
-        </select>
-        <label htmlFor="gen">Gen:</label>
-        <select id="gen">
-          <option value="none">---</option>
-          {validGens.map(gen => (
-            <option key={`gen-option-${gen}`} value={gen}>{gen}</option>)
-          )}
-        </select>
-        <button onClick={() => {
-          const type1Select: HTMLSelectElement | null = document.querySelector('#type1')
-          const type2Select: HTMLSelectElement | null = document.querySelector('#type2')
-          const genSelect: HTMLSelectElement | null = document.querySelector('#gen')
-
-          const type1Value = type1Select!.value
-          const type2Value = type2Select!.value
-          const genValue = genSelect!.value
-          let navlink = ['/filtered?']
-
-          if (genValue !== 'none') {
-            navlink.push(`gen=${genValue}`)
-          } 
-          if (type1Value !== 'none') {
-            navlink.push(`type1=${type1Value}`)
-          }
-          if (type2Value !== 'none') {
-            navlink.push(`type2=${type2Value}`)
-          }
-
-          if (navlink.length !== 1) navigate(navlink.join('&'))
-
-        }}>search</button>
+        />
       </div>
-      <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
-        {previewData.map(fetchedPokemon => (
-          <PokemonPreviewCard 
-            id={fetchedPokemon.id}
-            name={fetchedPokemon.name}
-            key={`pokemon-${fetchedPokemon.id}`}
-          />
-        ))}
-      </div>
-    </>
+    </CenteredFlexColGap>
   )
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,7 @@
-import PokemonPreviewCard from "../components/PokemonPreviewCard";
 import { useEffect } from "react";
+
+import ArrayToJSXTransformer from "../components/ArrayToJSXTransformer";
+import PokemonPreviewCard from "../components/PokemonPreviewCard";
 import useInfinitePokemonsPreviewData from "../hooks/useInfinitePokemonsPreviewData";
 import useOnScreen from "../hooks/useOnScreen";
 
@@ -29,13 +31,16 @@ function Home() {
   return (
     <>
       <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
-        {previewData.map(fetchedPokemon => (
-          <PokemonPreviewCard 
-            id={fetchedPokemon.id} 
-            name={fetchedPokemon.name} 
-            key={`pokemon-${fetchedPokemon.id}`}
+        <ArrayToJSXTransformer
+            dataArray={previewData}
+            transformer={(pokemon) => (
+              <PokemonPreviewCard 
+                id={pokemon.id} 
+                name={pokemon.name} 
+                key={`pokemon-${pokemon.id}`}
+              />
+            )}
           />
-        ))}
       </div>
       <div ref={ref}>{isLoadingMorePokemons && <h1>Loading more pokemons...</h1>}</div>
     </>


### PR DESCRIPTION
## Description

Added a proper UI to handle user options for filtering searches.

## Motivation

There was never a way of using this feature if not by changing the URL directly and adding the parameters directly.

### Example:

there is: 

"/filtered"

if user would like to fetch only pokemons from gen 1, it was necessary to do something like:

"/filtered?gen=1"

if user would like to fetch only pokemons from gen 1 and with type fire:

"/filtered?gen=1&type1=fire"

It's about time to add a proper UI so that the user stop having to manually change the URL.

## Current behavior

User has to manually change the URL to use the filtered search feature.

## Expected behavior

User manages the filtering options through a proper UI.

## Describe changes

- Added "FilteringOptionsUI" component, it handles all logic and elemenets related to the filtering options.
- Fixed param handling in all hooks related with filtered searches: early return before a hook declaration is not a good practice and was causing problems.