### PR TITLE
feature: display modal for pokemon varieties

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.9.0</title>
+    <title>Really Simple Pokedex V1.10.0</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.9.0" ,
+  "version": "1.10.0" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/PokemonCard.tsx
+++ b/src/components/PokemonCard.tsx
@@ -1,4 +1,3 @@
-import { capitalize } from "../functions/other-functions"
 import { getPokemonTypeColor, getPokemonWrapperTypeColor } from "../functions/poke-functions"
 import { PokedexEntry } from "../types/pokemon-related-types"
 import { SubTitle, Text, Title } from "./main-components"
@@ -34,7 +33,7 @@ function PokemonCard({
   return (
     <PokemonCardWrapper $backgroundColor={getPokemonWrapperTypeColor(types[0])}>
       <PokemonStatsWrapper $backgroundColor={getPokemonTypeColor(types[0])}>
-        <Title $color="#fff">{capitalize(name)}</Title>
+        <Title $color="#fff">{name}</Title>
         <PokemonSpriteWrapper>
           <PokemonSprite src={`${spriteSrc}`} width={250} height={250}/>
         </PokemonSpriteWrapper>

--- a/src/components/PokemonEvolutionChain.tsx
+++ b/src/components/PokemonEvolutionChain.tsx
@@ -34,7 +34,7 @@ function PokemonEvolutionChain({ chainLink, type }: { chainLink: ChainLink, type
           <Title $color="#fff">Evolution Chain</Title>
         </SectionTitleWrapper>
         <PokemonEvolutionChainWrapper $backgroundColor={getPokemonWrapperTypeColor(type)}>
-          <Title $color="#fff">This Pokemon has no evolutions or pre-evolutions</Title>
+          <Title $color="#fff">This Pokemon is not in a evolution chain.</Title>
         </PokemonEvolutionChainWrapper>
       </div>
     )

--- a/src/components/PokemonPreviewCard.tsx
+++ b/src/components/PokemonPreviewCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 
-import { capitalize } from "../functions/other-functions";
 import { getPokemonTypeColor } from "../functions/poke-functions";
 import useImagePreloader from "../hooks/useImagePreloader";
 import useOnScreen from "../hooks/useOnScreen";
@@ -40,7 +39,7 @@ function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
     >
       <NoDecorationLink to={`/pokemon/${data.id}`} style={{borderBottomRightRadius: '4rem', borderTopLeftRadius: '4rem'}}>
         <PokemonPreviewCardWrapper ref={ref} $backgroundColor={getPokemonTypeColor(data.types[0])}>
-          <Title $color="#fff">{capitalize(data.name)}</Title>
+          <Title $color="#fff">{data.name}</Title>
           <PokemonSpriteWrapper>
             <PokemonSprite src={data.spriteSrc} alt={`pokemon ${data.id}`}/>
           </PokemonSpriteWrapper>

--- a/src/components/PokemonVarieties.tsx
+++ b/src/components/PokemonVarieties.tsx
@@ -26,7 +26,7 @@ function PokemonVarieties({ type, varieties }: { type: string, varieties: Variet
       <SectionTitleWrapper $backgroundColor={getPokemonTypeColor(type)}>
         <Title $color="#fff">Other Varieties</Title>
       </SectionTitleWrapper>
-      <PokemonVarietiesWrapper $gap={'2rem'} $backgroundColor={getPokemonWrapperTypeColor(type)}>
+      <PokemonVarietiesWrapper $gap={'3rem'} $backgroundColor={getPokemonWrapperTypeColor(type)}>
         {result.map(item => (
           <PokemonVarietyCard
             id={item.id}

--- a/src/components/PokemonVarietyCard.tsx
+++ b/src/components/PokemonVarietyCard.tsx
@@ -1,31 +1,107 @@
+import { useState } from "react";
+
+import { capitalize } from "../functions/other-functions";
+import { getPokemonTypeColor } from "../functions/poke-functions";
 import useImagePreloader from "../hooks/useImagePreloader";
 import usePokemonVariety from "../hooks/usePokemonVariety"
+import useSinglePokemonData from "../hooks/useSinglePokemonData";
 import HoverableGrowthFeedback from "./feedbacks/HoverableGrowthFeedback";
 import PokemonVarietyCardLoadingFeedback from "./feedbacks/PokemonVarietyCardLoadingFeedback";
-import { CenteredFlexCol, NoDecorationLink, Title } from "./main-components";
-import { PokemonSpriteChainLink, PokemonSpriteWrapperChainLink } from "./styles";
+import {
+  CenteredFlexCol,
+  SubTitle,
+  Text,
+  Title
+} from "./main-components";
+import { Modal } from "./main-modal-components";
+import { PokemonSprite, PokemonSpriteWrapper } from "./main-poke-components";
+import {
+  PokemonSpriteChainLink,
+  PokemonSpriteWrapperChainLink,
+  PokemonType,
+  PokemonTypesWrapper,
+  PokemonVarietyStatsWrapper
+} from "./styles";
 
 function PokemonVarietyCard({ id, name }: { id: number, name: string }) {
-  const { data, isLoading } = usePokemonVariety(id)
-  const { hasLoaded } = useImagePreloader(data ? data.spriteSrc : '')
+  const { data: varietyData, isLoading: varietyIsLoading } = usePokemonVariety(id)
+  const { 
+    data: singlePokemonData, 
+    isLoading: singlePokemonIsLoading
+   } = useSinglePokemonData(varietyData ? varietyData.id : 1)
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const { hasLoaded: varietyHasLoaded } = useImagePreloader(varietyData ? varietyData.spriteSrc : '')
+  const { hasLoaded: singlePokemonHasLoaded } = useImagePreloader(singlePokemonData ? singlePokemonData.spriteSrc : '')
 
-  
-  if (data === null || isLoading || hasLoaded === false) {
-    return <PokemonVarietyCardLoadingFeedback id={id} name={name}/>
+  if (
+    varietyData === null || 
+    singlePokemonData === null ||
+    varietyIsLoading || 
+    singlePokemonIsLoading || 
+    (varietyHasLoaded === false && varietyData.spriteSrc !== null) ||
+    singlePokemonHasLoaded === false
+  ) {
+    return <PokemonVarietyCardLoadingFeedback name={name}/>
   }
 
 
   return (
-    <HoverableGrowthFeedback>
-      <NoDecorationLink to={`/pokemon/${data.id}`}>
+    <div>
+      {
+        isModalOpen &&
+        <Modal setIsModalOpen={setIsModalOpen}>
+          <PokemonVarietyStatsWrapper 
+            $backgroundColor={getPokemonTypeColor(singlePokemonData.types[0])}
+            > 
+            <Title $color="#fff">{capitalize(singlePokemonData.name)}</Title>
+            <PokemonSpriteWrapper>
+              <PokemonSprite 
+                src={`${singlePokemonData.spriteSrc}`} 
+                alt={`pokemon ${singlePokemonData.id}`} 
+                width={250} 
+                height={250}
+              />
+            </PokemonSpriteWrapper>
+            <SubTitle $color="#fff">ID: <Text>{singlePokemonData.id}</Text></SubTitle>
+            <SubTitle $color="#fff">Gen: <Text>{singlePokemonData.gen}</Text></SubTitle>
+            <SubTitle $color="#fff">Height: <Text>{singlePokemonData.height}m</Text></SubTitle>
+            <SubTitle $color="#fff">Weight: <Text>{singlePokemonData.weight}kg</Text></SubTitle>
+            <PokemonTypesWrapper>
+              {singlePokemonData.types.map(
+                type => <PokemonType key={`pokemon-type-${type}-2`} type={type}/>
+              )}
+            </PokemonTypesWrapper>
+          </PokemonVarietyStatsWrapper>
+          <PokemonVarietyStatsWrapper 
+            $backgroundColor={getPokemonTypeColor(varietyData.types[0])}
+            >
+            <Title $color="#fff">{capitalize(varietyData.name)}</Title>
+            <PokemonSpriteWrapper>
+              <PokemonSprite 
+                src={`${varietyData.spriteSrc}`} 
+                alt={`pokemon ${varietyData.name}`} width={250} height={250}/>
+            </PokemonSpriteWrapper>
+            <SubTitle $color="#fff">ID: <Text>{varietyData.id}</Text></SubTitle>
+            <SubTitle $color="#fff">Gen: <Text>{varietyData.gen}</Text></SubTitle>
+            <SubTitle $color="#fff">Height: <Text>{varietyData.height}m</Text></SubTitle>
+            <SubTitle $color="#fff">Weight: <Text>{varietyData.weight}kg</Text></SubTitle>
+            <PokemonTypesWrapper>
+              {varietyData.types.map(
+                type => <PokemonType key={`pokemon-type-${type}-1`} type={type}/>
+              )}
+            </PokemonTypesWrapper>
+          </PokemonVarietyStatsWrapper>
+        </Modal>
+      }
+      <HoverableGrowthFeedback onClick={() => setIsModalOpen(!isModalOpen)}>
         <CenteredFlexCol $gap={'1rem'}>
           <PokemonSpriteWrapperChainLink>
-            <PokemonSpriteChainLink src={data.spriteSrc} alt={`pokemon ${data.name}`}/>
+            <PokemonSpriteChainLink src={varietyData.spriteSrc} alt={`pokemon ${varietyData.name}`}/>
           </PokemonSpriteWrapperChainLink> 
-          <Title $color="#fff">{data.name}</Title>
+          <Title $color="#fff">{varietyData.name}</Title>
         </CenteredFlexCol>
-      </NoDecorationLink>
-    </HoverableGrowthFeedback>
+      </HoverableGrowthFeedback>
+    </div>
   )
 }
 

--- a/src/components/PokemonVarietyCard.tsx
+++ b/src/components/PokemonVarietyCard.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 
-import { capitalize } from "../functions/other-functions";
 import { getPokemonTypeColor } from "../functions/poke-functions";
 import useImagePreloader from "../hooks/useImagePreloader";
 import usePokemonVariety from "../hooks/usePokemonVariety"
@@ -8,7 +7,6 @@ import useSinglePokemonData from "../hooks/useSinglePokemonData";
 import HoverableGrowthFeedback from "./feedbacks/HoverableGrowthFeedback";
 import PokemonVarietyCardLoadingFeedback from "./feedbacks/PokemonVarietyCardLoadingFeedback";
 import {
-  CenteredFlexCol,
   SubTitle,
   Text,
   Title
@@ -16,11 +14,10 @@ import {
 import { Modal } from "./main-modal-components";
 import { PokemonSprite, PokemonSpriteWrapper } from "./main-poke-components";
 import {
-  PokemonSpriteChainLink,
-  PokemonSpriteWrapperChainLink,
+  DivGap,
+  PokemonModalStatsWrapper,
   PokemonType,
-  PokemonTypesWrapper,
-  PokemonVarietyStatsWrapper
+  PokemonTypesWrapper
 } from "./styles";
 
 function PokemonVarietyCard({ id, name }: { id: number, name: string }) {
@@ -50,10 +47,10 @@ function PokemonVarietyCard({ id, name }: { id: number, name: string }) {
       {
         isModalOpen &&
         <Modal setIsModalOpen={setIsModalOpen}>
-          <PokemonVarietyStatsWrapper 
+          <PokemonModalStatsWrapper 
             $backgroundColor={getPokemonTypeColor(singlePokemonData.types[0])}
             > 
-            <Title $color="#fff">{capitalize(singlePokemonData.name)}</Title>
+            <Title $color="#fff">{singlePokemonData.name}</Title>
             <PokemonSpriteWrapper>
               <PokemonSprite 
                 src={`${singlePokemonData.spriteSrc}`} 
@@ -71,8 +68,9 @@ function PokemonVarietyCard({ id, name }: { id: number, name: string }) {
                 type => <PokemonType key={`pokemon-type-${type}-2`} type={type}/>
               )}
             </PokemonTypesWrapper>
-          </PokemonVarietyStatsWrapper>
-          <PokemonVarietyStatsWrapper 
+          </PokemonModalStatsWrapper>
+          <DivGap $width={'6rem'} onClick={() => setIsModalOpen(!isModalOpen)}/>
+          <PokemonModalStatsWrapper 
             $backgroundColor={getPokemonTypeColor(varietyData.types[0])}
             >
             <Title $color="#fff">{varietyData.name}</Title>
@@ -90,16 +88,13 @@ function PokemonVarietyCard({ id, name }: { id: number, name: string }) {
                 type => <PokemonType key={`pokemon-type-${type}-1`} type={type}/>
               )}
             </PokemonTypesWrapper>
-          </PokemonVarietyStatsWrapper>
+          </PokemonModalStatsWrapper>
         </Modal>
       }
-      <HoverableGrowthFeedback onClick={() => setIsModalOpen(!isModalOpen)}>
-        <CenteredFlexCol $gap={'1rem'}>
-          <PokemonSpriteWrapperChainLink>
-            <PokemonSpriteChainLink src={varietyData.spriteSrc} alt={`pokemon ${varietyData.name}`}/>
-          </PokemonSpriteWrapperChainLink> 
-          <Title $color="#fff">{varietyData.name}</Title>
-        </CenteredFlexCol>
+      <HoverableGrowthFeedback $pointingCursor onClick={() => setIsModalOpen(!isModalOpen)}>
+        <PokemonSpriteWrapper>
+          <PokemonSprite src={varietyData.spriteSrc} alt={`pokemon ${varietyData.name}`}/>
+        </PokemonSpriteWrapper> 
       </HoverableGrowthFeedback>
     </div>
   )

--- a/src/components/PokemonVarietyCard.tsx
+++ b/src/components/PokemonVarietyCard.tsx
@@ -75,7 +75,7 @@ function PokemonVarietyCard({ id, name }: { id: number, name: string }) {
           <PokemonVarietyStatsWrapper 
             $backgroundColor={getPokemonTypeColor(varietyData.types[0])}
             >
-            <Title $color="#fff">{capitalize(varietyData.name)}</Title>
+            <Title $color="#fff">{varietyData.name}</Title>
             <PokemonSpriteWrapper>
               <PokemonSprite 
                 src={`${varietyData.spriteSrc}`} 

--- a/src/components/feedbacks/HoverableGrowthFeedback.tsx
+++ b/src/components/feedbacks/HoverableGrowthFeedback.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components"
 
-const HoverableGrowthFeedback = styled.span<{
+const HoverableGrowthFeedback = styled.div<{
   $borderRadius?: string | number;
   $borderTopLeftRadius?: string | number;
   $borderTopRightRadius?: string | number;
@@ -20,7 +20,7 @@ const HoverableGrowthFeedback = styled.span<{
 
   transition: .2s;
   outline: 0px solid #fff;
-  &: hover {
+  &:hover {
     ${props => props.$outline ? 'outline: 3px solid #fff' : ''};
     z-index: 999;
     transform: scale(${props => props.$growthScale ?? '1.2'});

--- a/src/components/feedbacks/HoverableGrowthFeedback.tsx
+++ b/src/components/feedbacks/HoverableGrowthFeedback.tsx
@@ -1,13 +1,14 @@
 import styled from "styled-components"
 
 const HoverableGrowthFeedback = styled.div<{
-  $borderRadius?: string | number;
-  $borderTopLeftRadius?: string | number;
-  $borderTopRightRadius?: string | number;
-  $borderBottomLeftRadius?: string | number;
-  $borderBottomRightRadius?: string | number;
-  $growthScale?: number;
-  $outline?: boolean;
+  $borderRadius?: string | number,
+  $borderTopLeftRadius?: string | number
+  $borderTopRightRadius?: string | number,
+  $borderBottomLeftRadius?: string | number,
+  $borderBottomRightRadius?: string | number,
+  $growthScale?: number,
+  $outline?: boolean,
+  $pointingCursor?: boolean
 }>`
   ${ props => props.$borderRadius ? `
     border-radius: ${props.$borderRadius ? typeof props.$borderRadius === 'string' ? props.$borderRadius : `${props.$borderRadius}px` : 'initial'};
@@ -17,6 +18,8 @@ const HoverableGrowthFeedback = styled.div<{
     border-bottom-left-radius: ${props.$borderBottomLeftRadius ? typeof props.$borderBottomLeftRadius === 'string' ? props.$borderBottomLeftRadius : `${props.$borderBottomLeftRadius}px` : 'initial'};
     border-bottom-right-radius: ${props.$borderBottomRightRadius ? typeof props.$borderBottomRightRadius === 'string' ? props.$borderBottomRightRadius : `${props.$borderBottomRightRadius}px` : 'initial'};`
   }
+
+  ${props => props.$pointingCursor ? 'cursor: pointer;' : ''}
 
   transition: .2s;
   outline: 0px solid #fff;

--- a/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
@@ -1,6 +1,5 @@
 import { forwardRef } from "react"
 
-import { capitalize } from "../../functions/other-functions"
 import { NoDecorationLink, Title } from "../main-components"
 import { PokemonPreviewCardWrapper, PokemonSpriteWrapper } from "../main-poke-components"
 import HoverableGrowthFeedback from "./HoverableGrowthFeedback"
@@ -19,7 +18,7 @@ const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement,
     >
       <NoDecorationLink to={`/pokemon/${props.id}`}>
         <PokemonPreviewCardWrapper ref={ref}>
-          <Title $color="#fff">{capitalize(props.name)}</Title>
+          <Title $color="#fff">{props.name}</Title>
           <PokemonSpriteWrapper>
             <RotatingPokeballFeedback pokemonId={props.id}/>
           </PokemonSpriteWrapper>

--- a/src/components/feedbacks/PokemonVarietyCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonVarietyCardLoadingFeedback.tsx
@@ -1,14 +1,10 @@
-import { CenteredFlexCol, Title } from "../main-components"
 import HoverableGrowthFeedback from "./HoverableGrowthFeedback"
 import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
 
 function PokemonVarietyCardLoadingFeedback({ name }: { name: string }) {
   return ( 
     <HoverableGrowthFeedback>
-      <CenteredFlexCol $gap="1rem"> 
-        <RotatingPokeballFeedback pokemonId={name} width={175} height={175}/>
-        <Title $color="#fff">{name}</Title>
-      </CenteredFlexCol>
+      <RotatingPokeballFeedback pokemonId={name} width={250} height={250}/>
     </HoverableGrowthFeedback>
    )
 }

--- a/src/components/feedbacks/PokemonVarietyCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonVarietyCardLoadingFeedback.tsx
@@ -1,16 +1,14 @@
-import { CenteredFlexCol, NoDecorationLink, Title } from "../main-components"
+import { CenteredFlexCol, Title } from "../main-components"
 import HoverableGrowthFeedback from "./HoverableGrowthFeedback"
 import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
 
-function PokemonVarietyCardLoadingFeedback({ id, name }: { id: number, name: string }) {
+function PokemonVarietyCardLoadingFeedback({ name }: { name: string }) {
   return ( 
     <HoverableGrowthFeedback>
-      <NoDecorationLink to={`/pokemon/${id}`}>
-        <CenteredFlexCol $gap="1rem"> 
-          <RotatingPokeballFeedback pokemonId={name} width={175} height={175}/>
-          <Title $color="#fff">{name}</Title>
-        </CenteredFlexCol>
-      </NoDecorationLink>
+      <CenteredFlexCol $gap="1rem"> 
+        <RotatingPokeballFeedback pokemonId={name} width={175} height={175}/>
+        <Title $color="#fff">{name}</Title>
+      </CenteredFlexCol>
     </HoverableGrowthFeedback>
    )
 }

--- a/src/components/main-modal-components.tsx
+++ b/src/components/main-modal-components.tsx
@@ -1,0 +1,65 @@
+import { ReactNode, useEffect } from "react"
+import styled, { keyframes } from "styled-components"
+
+import { CenteredFlexCol, CenteredFlexRow } from "./main-components"
+
+const FadeInAnimation = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+`
+const ModalBackground = styled(CenteredFlexCol)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 999;
+  background-color: rgba(0,0,0,0.6);
+  width: 100vw;
+  height: 100vh;
+  animation: ${FadeInAnimation} linear 0.1s;
+`
+
+const ModalBox = styled(CenteredFlexRow)`
+  position: fixed;
+  top: 0; 
+  left: 0;
+  z-index: 1000;
+  margin-top: 20vh;
+  margin-left: 25vw;
+  animation: ${FadeInAnimation} linear 0.1s;
+`
+
+
+export const Modal = ({ children, setIsModalOpen }: { children: ReactNode, setIsModalOpen: (value: boolean) => void }) => {  
+  let scrollBarWidth = window.innerWidth - document.body.offsetWidth
+  
+  useEffect(() => {
+    const windowHeight = window.innerHeight
+    const bodyHeight = document.body.offsetHeight
+
+    if (bodyHeight > windowHeight) {
+      document.body.style.height = '100%'
+      document.body.style.overflowY = 'hidden'
+      document.body.style.marginRight = `${scrollBarWidth}px`
+    }
+    
+    return () => {
+      document.body.style.height = ''
+      document.body.style.overflow = ''
+      document.body.style.marginRight = ``
+    }
+  }, []);
+
+  return (
+    <>
+    <ModalBackground onClick={() => setIsModalOpen(false)}/>
+      <ModalBox $gap={'5rem'}>
+      { children }
+      </ModalBox>
+    </>
+  )
+}

--- a/src/components/main-modal-components.tsx
+++ b/src/components/main-modal-components.tsx
@@ -57,7 +57,7 @@ export const Modal = ({ children, setIsModalOpen }: { children: ReactNode, setIs
   return (
     <>
     <ModalBackground onClick={() => setIsModalOpen(false)}/>
-      <ModalBox $gap={'5rem'}>
+      <ModalBox>
       { children }
       </ModalBox>
     </>

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -66,10 +66,10 @@ export const CenteredFlexColGap = styled(CenteredFlexCol)`
   gap: 3rem;
 `
 export const PokemonStatsWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string}>`
-  width: 30%;
   border-top-left-radius: 4rem;
   background-color: ${(props) => props.$backgroundColor ? props.$backgroundColor : '#d4d4d4'};
   padding: 1.5rem;
+  width: 30%;
   gap: 1.5rem;
 ` 
 export const PokemonTypesWrapper = styled(CenteredFlexRow)`
@@ -230,4 +230,12 @@ export const SectionTitleWrapper = styled.div<{ $backgroundColor: string }>`
 `
 export const RotateImage = styled.img<{ $angle?: number }>`
   transform: rotate(${props => props.$angle ? props.$angle : 0}deg);
+`
+export const PokemonVarietyStatsWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string}>`
+  border-top-left-radius: 4rem;
+  border-bottom-right-radius: 4rem;
+  background-color: ${(props) => props.$backgroundColor ? props.$backgroundColor : '#d4d4d4'};
+  padding: 1.5rem;
+  min-width: 19vw;
+  gap: 1.5rem;
 `

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -231,11 +231,15 @@ export const SectionTitleWrapper = styled.div<{ $backgroundColor: string }>`
 export const RotateImage = styled.img<{ $angle?: number }>`
   transform: rotate(${props => props.$angle ? props.$angle : 0}deg);
 `
-export const PokemonVarietyStatsWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string}>`
+export const PokemonModalStatsWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string}>`
   border-top-left-radius: 4rem;
   border-bottom-right-radius: 4rem;
   background-color: ${(props) => props.$backgroundColor ? props.$backgroundColor : '#d4d4d4'};
   padding: 1.5rem;
   min-width: 19vw;
   gap: 1.5rem;
+`
+export const DivGap = styled.div<{ $width?: string | number}>`
+  align-self: stretch;
+  width: ${props => props.$width ? typeof props.$width === 'string' ? props.$width : `${props.$width}px` : '1rem'};
 `

--- a/src/functions/poke-functions.ts
+++ b/src/functions/poke-functions.ts
@@ -55,7 +55,7 @@ export async function getPokemonVarietyData(id: number) {
   const pokemonTypes = rawPokemonPageData.types.map(item => item.type.name)
 
   return {
-    id: rawPokemonPageData.id,
+    id: rawSpeciesPageData.id,
     gen: getGenFromFetchedData(rawSpeciesPageData),
     name: rawPokemonPageData.name,
     weight: rawPokemonPageData.weight / 10, // ??? -> KG

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 
-import ArrayToJSXTransformer from "../components/ArrayToJSXTransformer";
 import PokemonPreviewCard from "../components/PokemonPreviewCard";
 import useInfinitePokemonsPreviewData from "../hooks/useInfinitePokemonsPreviewData";
 import useOnScreen from "../hooks/useOnScreen";
@@ -31,16 +30,13 @@ function Home() {
   return (
     <>
       <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
-        <ArrayToJSXTransformer
-            dataArray={previewData}
-            transformer={(pokemon) => (
-              <PokemonPreviewCard 
-                id={pokemon.id} 
-                name={pokemon.name} 
-                key={`pokemon-${pokemon.id}`}
-              />
-            )}
+        {previewData.map(pokemon => (
+          <PokemonPreviewCard 
+            id={pokemon.id} 
+            name={pokemon.name} 
+            key={`pokemon-${pokemon.id}`}
           />
+        ))}
       </div>
       <div ref={ref}>{isLoadingMorePokemons && <h1>Loading more pokemons...</h1>}</div>
     </>

--- a/src/types/pokemon-api-page-types.ts
+++ b/src/types/pokemon-api-page-types.ts
@@ -1,0 +1,158 @@
+import {
+  Ability,
+  ChainLink,
+  Cries,
+  FormDescription,
+  GameIndiceGen,
+  GameIndiceVersion,
+  Genera,
+  HeldItem,
+  Move,
+  Name,
+  NamedAPIResource,
+  PalParkEncounter,
+  PokedexEntry,
+  PokedexNumber,
+  PokemonType,
+  Sprites,
+  StatDetails,
+  TypePokemon,
+  TypeRelations,
+  Variety
+} from "./pokemon-related-types"
+
+export type GenPage = {
+  id: number,
+  name: string,
+  abilities: NamedAPIResource[],
+  names: Name[],
+  main_region: NamedAPIResource,
+  moves: NamedAPIResource[],
+  pokemon_species: NamedAPIResource[],
+  types: NamedAPIResource[],
+  version_groups: NamedAPIResource[]
+}
+
+
+
+export type SpeciesPage = {
+  base_hapiness: number,
+  capture_rate: number,
+  color: NamedAPIResource,
+  egg_groups: NamedAPIResource[],
+  evolution_chain: { url: string },
+  evolves_from_species: NamedAPIResource | null,
+  flavor_text_entries: PokedexEntry[],
+  form_description: FormDescription[],
+  forms_switchable: boolean,
+  gender_rate: number,
+  genera: Genera[],
+  generation: NamedAPIResource,
+  growth_rate: NamedAPIResource,
+  habitat: NamedAPIResource,
+  has_gender_differences: boolean,
+  hatch_counter: number,
+  id: number,
+  is_baby: boolean,
+  is_legendary: boolean,
+  is_mythical: boolean,
+  name: string,
+  names: Name[],
+  order: number,
+  pal_park_encounters: PalParkEncounter[],
+  pokedex_numbers: PokedexNumber[],
+  shape: NamedAPIResource,
+  varieties: Variety[]
+}
+
+
+
+export type PokemonPage = {
+  abilities: Ability[]
+  base_experience: number,
+  cries: Cries,
+  forms: NamedAPIResource[],
+  game_indices: GameIndiceVersion[],
+  height: number,
+  held_items: HeldItem[]
+  id: number,
+  is_default: boolean,
+  location_area_encounters: string,
+  moves: Move[],
+  name: string,
+  order: number,
+  past_abilities: NamedAPIResource[],
+  past_types: NamedAPIResource[],
+  species: NamedAPIResource,
+  sprites: Sprites,
+  stats: StatDetails[],
+  types: PokemonType[],
+  weight: number
+}
+
+
+
+export type PokemonTypePage = {
+  damage_relations: TypeRelations,
+  game_indices: GameIndiceGen[],
+  generation: NamedAPIResource,
+  id: number,
+  move_damage_class: NamedAPIResource | null,
+  moves: NamedAPIResource[],
+  name: string,
+  names: Name[],
+  past_damage_relations: {
+    damage_relations: TypeRelations,
+    generation: NamedAPIResource
+  }[],
+  pokemon: TypePokemon[]
+}
+
+
+
+export type EvolutionChainPage = {
+  baby_trigger_item: NamedAPIResource | null,
+  chain: ChainLink
+  id: number
+}
+
+
+
+export type PokemonFormPage = {
+  form_name: string,
+  form_names: Name[],
+  form_order: number,
+  id: number,
+  is_battle_only: boolean,
+  is_default: boolean,
+  is_mega: boolean,
+  name: string,
+  names: Name[],
+  order: number,
+  pokemon: NamedAPIResource,
+  sprites: {
+    back_default: string | null,
+    back_female: string | null,
+    back_shiny: string | null,
+    back_shiny_female: string | null,
+    front_default: string | null,
+    front_female: string | null,
+    front_shiny: string | null,
+    front_shiny_female: string | null
+  },
+  types: PokemonType[],
+  version_group: NamedAPIResource
+}
+
+
+
+export type VersionGroupPage = {
+  generation: NamedAPIResource,
+  id: number,
+  move_learn_methods: NamedAPIResource[],
+  name: string,
+  order: number,
+  pokedexes: NamedAPIResource[],
+  regions: NamedAPIResource[],
+  versions: NamedAPIResource[]
+}

--- a/src/types/pokemon-related-types.ts
+++ b/src/types/pokemon-related-types.ts
@@ -1,4 +1,4 @@
-type PokemonType = {
+export type PokemonType = {
   type: NamedAPIResource
   slot: number, 
 }
@@ -56,35 +56,23 @@ export type PokemonsPreviewDataStatus = {
   isLoading: boolean
 }
 
-export type GenPage = {
-  id: number,
-  name: string,
-  abilities: NamedAPIResource[],
-  names: Name[],
-  main_region: NamedAPIResource,
-  moves: NamedAPIResource[],
-  pokemon_species: NamedAPIResource[],
-  types: NamedAPIResource[],
-  version_groups: NamedAPIResource[]
-}
-
-type FormDescription = {
+export type FormDescription = {
   description: string,
   language: NamedAPIResource 
 }
 
-type Genera = {
+export type Genera = {
   genus: string,
   language: NamedAPIResource
 }
 
-type PalParkEncounter = {
+export type PalParkEncounter = {
   area: NamedAPIResource,
   base_score: number,
   rate: number
 }
 
-type PokedexNumber = {
+export type PokedexNumber = {
   entry_number: number,
   pokedex: NamedAPIResource
 }
@@ -94,74 +82,44 @@ export type Variety = {
   pokemon: NamedAPIResource
 }
 
-export type SpeciesPage = {
-  base_hapiness: number,
-  capture_rate: number,
-  color: NamedAPIResource,
-  egg_groups: NamedAPIResource[],
-  evolution_chain: { url: string },
-  evolves_from_species: NamedAPIResource | null,
-  flavor_text_entries: PokedexEntry[],
-  form_description: FormDescription[],
-  forms_switchable: boolean,
-  gender_rate: number,
-  genera: Genera[],
-  generation: NamedAPIResource,
-  growth_rate: NamedAPIResource,
-  habitat: NamedAPIResource,
-  has_gender_differences: boolean,
-  hatch_counter: number,
-  id: number,
-  is_baby: boolean,
-  is_legendary: boolean,
-  is_mythical: boolean,
-  name: string,
-  names: Name[],
-  order: number,
-  pal_park_encounters: PalParkEncounter[],
-  pokedex_numbers: PokedexNumber[],
-  shape: NamedAPIResource,
-  varieties: Variety[]
-}
-
-type Ability = {
+export type Ability = {
   ability: NamedAPIResource,
   is_hidden : boolean,
   slot: number
 }
 
-type Cries = {
+export type Cries = {
   latest: string,
   legacy: string | null
 }
 
-type GameIndiceVersion = {
+export type GameIndiceVersion = {
   game_index: number,
   version: NamedAPIResource
 }
 
-type VersionDetail = {
+export type VersionDetail = {
   rarity: number,
   version: NamedAPIResource
 }
 
-type HeldItem = {
+export type HeldItem = {
   item: NamedAPIResource,
   version_details: VersionDetail[]
 }
 
-type VersionGroupDetail = {
+export type VersionGroupDetail = {
   level_learned_at: number,
   move_learn_method: NamedAPIResource,
   version_group: NamedAPIResource
 }
 
-type Move = {
+export type Move = {
   move: NamedAPIResource,
   version_group_details: VersionGroupDetail[]
 }
 
-type OtherSprites = { 
+export type OtherSprites = { 
   dream_world: {
     front_default: string,
     front_female: string | null
@@ -188,7 +146,7 @@ type OtherSprites = {
   }
 }
 
-type Sprites = {
+export type Sprites = {
   back_default: string,
   back_female: string | null,
   back_shiny: string,
@@ -349,42 +307,18 @@ type Sprites = {
  }
 }
 
-type StatDetails = {
+export type StatDetails = {
   base_stat: number,
   effort: number,
   stat: NamedAPIResource
 }
 
-export type PokemonPage = {
-  abilities: Ability[]
-  base_experience: number,
-  cries: Cries,
-  forms: NamedAPIResource[],
-  game_indices: GameIndiceVersion[],
-  height: number,
-  held_items: HeldItem[]
-  id: number,
-  is_default: boolean,
-  location_area_encounters: string,
-  moves: Move[],
-  name: string,
-  order: number,
-  past_abilities: NamedAPIResource[],
-  past_types: NamedAPIResource[],
-  species: NamedAPIResource,
-  sprites: Sprites,
-  stats: StatDetails[],
-  types: PokemonType[],
-  weight: number
-}
-
-
-type GameIndiceGen = {
+export type GameIndiceGen = {
   game_index: number,
   generation: NamedAPIResource
 }
 
-type TypeRelations = {
+export type TypeRelations = {
   double_damage_from: NamedAPIResource[],
   double_damage_to: NamedAPIResource[]
   half_damage_from: NamedAPIResource[]
@@ -393,25 +327,9 @@ type TypeRelations = {
   no_damage_to: NamedAPIResource[]
 }
 
-type TypePokemon = {
+export type TypePokemon = {
   pokemon: NamedAPIResource,
   slot: number
-}
-
-export type PokemonTypePage = {
-  damage_relations: TypeRelations,
-  game_indices: GameIndiceGen[],
-  generation: NamedAPIResource,
-  id: number,
-  move_damage_class: NamedAPIResource | null,
-  moves: NamedAPIResource[],
-  name: string,
-  names: Name[],
-  past_damage_relations: {
-    damage_relations: TypeRelations,
-    generation: NamedAPIResource
-  }[],
-  pokemon: TypePokemon[]
 }
 
 export type ChainLink = {
@@ -421,7 +339,7 @@ export type ChainLink = {
   evolves_to: ChainLink[]
 }
 
-type EvolutionDetail = {
+export type EvolutionDetail = {
   item: NamedAPIResource | null,
   trigger: NamedAPIResource,
   gender: number | null,
@@ -440,42 +358,4 @@ type EvolutionDetail = {
   time_of_day: string,
   trade_species: NamedAPIResource | null,
   turn_upside_down: boolean
-}
-
-export type EvolutionChainPage = {
-  baby_trigger_item: NamedAPIResource | null,
-  chain: ChainLink
-  id: number
-}
-
-export type PokemonFormPage = {
-  form_name: string,
-  form_names: {
-    language: NamedAPIResource,
-    name: string
-  }[],
-  form_order: number,
-  id: number,
-  is_battle_only: boolean,
-  is_default: boolean,
-  is_mega: boolean,
-  name: string,
-  names: {
-    language: NamedAPIResource,
-    name: string
-  }[],
-  order: number,
-  pokemon: NamedAPIResource,
-  sprites: {
-    back_default: string | null,
-    back_female: string | null,
-    back_shiny: string | null,
-    back_shiny_female: string | null,
-    front_default: string | null,
-    front_female: string | null,
-    front_shiny: string | null,
-    front_shiny_female: string | null
-  },
-  types: PokemonType[],
-  version_group: NamedAPIResource
 }

--- a/src/types/pokemon-related-types.ts
+++ b/src/types/pokemon-related-types.ts
@@ -447,3 +447,35 @@ export type EvolutionChainPage = {
   chain: ChainLink
   id: number
 }
+
+export type PokemonFormPage = {
+  form_name: string,
+  form_names: {
+    language: NamedAPIResource,
+    name: string
+  }[],
+  form_order: number,
+  id: number,
+  is_battle_only: boolean,
+  is_default: boolean,
+  is_mega: boolean,
+  name: string,
+  names: {
+    language: NamedAPIResource,
+    name: string
+  }[],
+  order: number,
+  pokemon: NamedAPIResource,
+  sprites: {
+    back_default: string | null,
+    back_female: string | null,
+    back_shiny: string | null,
+    back_shiny_female: string | null,
+    front_default: string | null,
+    front_female: string | null,
+    front_shiny: string | null,
+    front_shiny_female: string | null
+  },
+  types: PokemonType[],
+  version_group: NamedAPIResource
+}


### PR DESCRIPTION
## Description

Instead of going to another single pokemon page and displaying the additional variety, now it will be displayed on the same page but in a modal. also changed the appearance of the "PokemonVarietyCard" component.

## Motivation

It is awkward going to another page every single time you click on a variety card.

## Images

Old Pokemon Variety Card
<img src="https://raw.githubusercontent.com/ArthurRodrigues01/really-simple-pokedex-app/assets/images/old-non-nameless-pokemon-variety-card.png" alt="old non nameless pokemon variety card"/>

New Pokemon Variety Card

<img src="https://raw.githubusercontent.com/ArthurRodrigues01/really-simple-pokedex-app/assets/images/new-nameless-pokemon-variety-card.png" alt="new nameless pokemon variety card"/>

## Current behavior

Going to another page  upon clicking a variety card.

## Expected behavior

Open a modal upon clicking a variety card.

## Describe changes

- Added "main-modal-components": for handling the modal component.
- Altered "PokemonVarietyCard": not displaying the name of the pokemon anymore just the image.