### PR TITLE
fixed: rotating pokeball loading feedbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.11.0</title>
+    <title>Really Simple Pokedex V1.11.1</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.11.0" ,
+  "version": "1.11.1" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/feedbacks/PokemonChainLinkLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonChainLinkLoadingFeedback.tsx
@@ -1,13 +1,11 @@
 import { NoDecorationLink } from "../main-components"
-import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
+import RotatingPokeballFeedbackChainLink from "./RotatingPokeballFeedbackChainLink"
 
 function PokemonChainLinkLoadingFeedback ({ id }: { id: number }) {
   return (
-      <NoDecorationLink to={`/pokemon/${id}`}>
-        <div> 
-          <RotatingPokeballFeedback pokemonId={id} width={175} height={175}/>
-        </div>
-      </NoDecorationLink>
+    <NoDecorationLink to={`/pokemon/${id}`}>
+      <RotatingPokeballFeedbackChainLink pokemonId={id}/>
+    </NoDecorationLink>
   )
 }
 

--- a/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react"
 
 import { NoDecorationLink, Title } from "../main-components"
-import { PokemonPreviewCardWrapper, PokemonSpriteWrapper } from "../poke-components/main-poke-components"
+import { PokemonPreviewCardWrapper } from "../poke-components/main-poke-components"
 import HoverableGrowthFeedback from "./HoverableGrowthFeedback"
 import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
 
@@ -19,9 +19,7 @@ const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement,
       <NoDecorationLink to={`/pokemon/${props.id}`}>
         <PokemonPreviewCardWrapper ref={ref}>
           <Title $color="#fff">{props.name}</Title>
-          <PokemonSpriteWrapper>
-            <RotatingPokeballFeedback pokemonId={props.id}/>
-          </PokemonSpriteWrapper>
+          <RotatingPokeballFeedback pokemonId={props.id}/>
           <Title $color="#fff">Loading...</Title>
         </PokemonPreviewCardWrapper>
       </NoDecorationLink>

--- a/src/components/feedbacks/PokemonVarietyCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonVarietyCardLoadingFeedback.tsx
@@ -4,7 +4,7 @@ import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
 function PokemonVarietyCardLoadingFeedback({ name }: { name: string }) {
   return ( 
     <HoverableGrowthFeedback>
-      <RotatingPokeballFeedback pokemonId={name} width={250} height={250}/>
+      <RotatingPokeballFeedback pokemonId={name}/>
     </HoverableGrowthFeedback>
    )
 }

--- a/src/components/feedbacks/RotatingPokeballFeedback.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedback.tsx
@@ -1,9 +1,30 @@
+import styled from "styled-components"
+
+import { DEVICE_QUERIES } from "../../constants/other-constants"
 import Rotate from "../Rotate"
 
-function RotatingPokeballFeedback({ pokemonId, height, width }: { pokemonId: number | string, height?: number, width?: number }) {
+function RotatingPokeballFeedback({ pokemonId }: { pokemonId: number | string }) {
+  const PokeballImg = styled.img`
+    width: 250px;
+    height: 250px;
+
+    @media ${DEVICE_QUERIES.tablet} {
+      width: 200px;
+      height: 200px;
+    }
+    
+    @media ${DEVICE_QUERIES.mobileL} {
+      width: 150px;
+      height: 150px;
+    }
+  `
+
   return (
     <Rotate>
-      <img src={"/really-simple-pokedex-app/pokeball.svg"} alt={`Loading pokemon ${pokemonId}`} style={{height: height ?? 200, width: width ?? 200}}/>
+      <PokeballImg 
+        src={"/really-simple-pokedex-app/pokeball.svg"} 
+        alt={`Loading pokemon ${pokemonId}`} 
+      />
     </Rotate>
   )
 }

--- a/src/components/feedbacks/RotatingPokeballFeedbackChainLink.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedbackChainLink.tsx
@@ -1,0 +1,27 @@
+import styled from "styled-components"
+
+import { DEVICE_QUERIES } from "../../constants/other-constants"
+import Rotate from "../Rotate"
+
+function RotatingPokeballFeedbackChainLink({ pokemonId }: { pokemonId: number | string }) {
+  const PokeballImg = styled.img`
+    width: 150px;
+    height: 150px;
+
+    @media ${DEVICE_QUERIES.tablet} {
+      width: 125px;
+      height: 125px;
+    }
+  `
+  
+  return (
+    <Rotate>
+      <PokeballImg
+        src={"/really-simple-pokedex-app/pokeball.svg"} 
+        alt={`Loading pokemon ${pokemonId}`}
+      />
+    </Rotate>
+  )
+}
+
+export default RotatingPokeballFeedbackChainLink

--- a/src/components/poke-components/main-poke-components.ts
+++ b/src/components/poke-components/main-poke-components.ts
@@ -30,12 +30,12 @@ export const PokemonSpriteWrapper = styled(CenteredFlexCol)`
   width: 250px;
 
   @media ${DEVICE_QUERIES.tablet} {
-    height: 170px;
-    width: 170px;
+    height: 200px;
+    width: 200px;
   }
   @media ${DEVICE_QUERIES.mobileL} {
-    height: 120px;
-    width: 120px;
+    height: 150px;
+    width: 150px;
   }
 `
 export const PokemonSprite = styled.img`
@@ -45,12 +45,12 @@ export const PokemonSprite = styled.img`
   max-height: 175px;
   
   @media ${DEVICE_QUERIES.tablet} {
-    max-width: 120px;
-    max-height: 120px;
+    max-width: 150px;
+    max-height: 150px;
   }
 
   @media ${DEVICE_QUERIES.mobileL} {
-    max-width: 70px;
-    max-height: 70px;
+    max-width: 100px;
+    max-height: 100px;
   }
 `

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -105,9 +105,9 @@ export const PokemonSectionTitleWrapper = styled.div<{ $backgroundColor: string 
   width: 950px;
   
   @media ${DEVICE_QUERIES.laptop} {
-    width: auto;
-    border-radius: 0;
     align-self: stretch;
+    border-radius: 0;
+    width: auto;
   }
 `
 export const DivGap = styled.div`


### PR DESCRIPTION
## Description

Adjusted proportions on Rotating pokeball loading feedbacks for smalller screens and changed the layout a bit.

## Motivation

It was really odd.

## Images

New loading feedback for evolution chain.
<img src="https://raw.githubusercontent.com/ArthurRodrigues01/really-simple-pokedex-app/assets/images/pokemon-evolution-chain-new.png" alt="pokemon evolution chain new"/>

Old loading feedback for evolution chain(while rotating its width changed and would trigger the overflow scrollbars).
<img src="https://raw.githubusercontent.com/ArthurRodrigues01/really-simple-pokedex-app/assets/images/pokemon-evolution-chain-old.png" alt="pokemon evolution chain old"/>

New loading feedback for pokemon preview card.
<img src="https://raw.githubusercontent.com/ArthurRodrigues01/really-simple-pokedex-app/assets/images/pokemon-preview-card-new.png" alt="pokemon preview card new"/>

Old loading feedback for pokemon preview card.
<img src="https://raw.githubusercontent.com/ArthurRodrigues01/really-simple-pokedex-app/assets/images/pokemon-preview-card-old.png" alt="pokemon preview card old"/>

## Current behavior

Proportions not adjusted for smaller screens.

## Expected behavior

Adjusted proportions for smaller screens.

## Describe changes

- Modified the rotating pokeball feedback and the other feedback components that used it. 