### PR TITLE
feature: styled loading more pokemons feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.12.0</title>
+    <title>Really Simple Pokedex V1.13.0</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.12.0" ,
+  "version": "1.13.0" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/PaginationBar.tsx
+++ b/src/components/PaginationBar.tsx
@@ -3,7 +3,11 @@ import { useQueryClient } from "@tanstack/react-query"
 import { getPokemonData } from "../functions/poke-functions"
 import { preloadImage } from "../hooks/useImagePreloader"
 import { CenteredFlexRow } from "./main-components"
-import { PaginationCell, PaginationCellCurrent } from "./styles/paginationBar-styles"
+import {
+  PaginationCell,
+  PaginationCellCurrent,
+  PokeballImg
+} from "./styles/paginationBar-styles"
 
 function PaginationBar ({ 
   growth,
@@ -72,14 +76,19 @@ function PaginationBar ({
 
   return (
     <CenteredFlexRow>
-      {
-        cells.map((item, index) => {
-          if (item === current) {
-            return <PaginationCellCurrent key={`pagination-button-${index}-deactivated`}>{item}</PaginationCellCurrent>
-          }
-          return <PaginationCell key={`pagination-button-${index}`} to={`/pokemon/${item}`}>{item}</PaginationCell>
-        })
-      }
+      {cells.map((item, index) => {
+        if (item === current) {
+          return (
+            <PaginationCellCurrent key={`pagination-button-${index}-deactivated`}>
+              <PokeballImg 
+                src={"/really-simple-pokedex-app/pokeball.svg"} 
+                alt='pokeball-img'
+              />
+            </PaginationCellCurrent>
+          )
+        }
+        return <PaginationCell key={`pagination-button-${index}`} to={`/pokemon/${item}`}>{item}</PaginationCell>
+      })}
     </CenteredFlexRow>
   )
 }

--- a/src/components/feedbacks/PokemonLoadingMoreFeedback.tsx
+++ b/src/components/feedbacks/PokemonLoadingMoreFeedback.tsx
@@ -1,0 +1,13 @@
+import { CenteredFlexRow, Title } from "../main-components"
+import RotatingPokeballFeedbackLoadingMore from "./RotatingPokeballFeedbackLoadingMore"
+
+function PokemonLoadingMoreFeedback() {
+  return ( 
+    <CenteredFlexRow $gap="3rem">
+      <RotatingPokeballFeedbackLoadingMore/>
+      <Title $color="#fff">Loading more Pokemons...</Title>
+    </CenteredFlexRow>
+  )
+}
+
+export default PokemonLoadingMoreFeedback

--- a/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
@@ -13,8 +13,8 @@ const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement,
   (props, ref) => {
   return (
     <HoverableGrowthFeedback
-      $borderBottomRightRadius={16} 
-      $borderTopLeftRadius={16}
+      $borderBottomRightRadius={'1rem'} 
+      $borderTopLeftRadius={'1rem'}
     >
       <NoDecorationLink to={`/pokemon/${props.id}`}>
         <PokemonPreviewCardWrapper ref={ref}>

--- a/src/components/feedbacks/RotatingPokeballFeedback.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedback.tsx
@@ -4,22 +4,21 @@ import { DEVICE_QUERIES } from "../../constants/other-constants"
 import Rotate from "../Rotate"
 
 const PokeballImg = styled.img`
-    width: 250px;
-    height: 250px;
+  width: 250px;
+  height: 250px;
 
-    @media ${DEVICE_QUERIES.tablet} {
-      width: 200px;
-      height: 200px;
-    }
-    
-    @media ${DEVICE_QUERIES.mobileL} {
-      width: 150px;
-      height: 150px;
-    }
-  `
+  @media ${DEVICE_QUERIES.tablet} {
+    width: 200px;
+    height: 200px;
+  }
+  
+  @media ${DEVICE_QUERIES.mobileL} {
+    width: 150px;
+    height: 150px;
+  }
+`
 
 function RotatingPokeballFeedback({ pokemonId }: { pokemonId?: number | string }) {
-
   return (
     <Rotate>
       <PokeballImg 

--- a/src/components/feedbacks/RotatingPokeballFeedbackLoadingMore.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedbackLoadingMore.tsx
@@ -4,24 +4,24 @@ import { DEVICE_QUERIES } from "../../constants/other-constants"
 import Rotate from "../Rotate"
 
 const PokeballImg = styled.img`
-  width: 150px;
-  height: 150px;
+  width: 125px;
+  height: 125px;
 
   @media ${DEVICE_QUERIES.tablet} {
-    width: 125px;
-    height: 125px;
+    width: 75px;
+    height: 75px;
   }
 `
 
-function RotatingPokeballFeedbackChainLink({ pokemonId }: { pokemonId: number | string }) {
+function RotatingPokeballFeedbackLoadingMore() {
   return (
     <Rotate>
-      <PokeballImg
+      <PokeballImg 
         src={"/really-simple-pokedex-app/pokeball.svg"} 
-        alt={`Loading pokemon ${pokemonId}`}
+        alt={'Loading more pokemons'}
       />
     </Rotate>
   )
 }
 
-export default RotatingPokeballFeedbackChainLink
+export default RotatingPokeballFeedbackLoadingMore

--- a/src/components/main-components.ts
+++ b/src/components/main-components.ts
@@ -3,14 +3,16 @@ import styled from "styled-components"
 
 import { DEVICE_QUERIES } from "../constants/other-constants"
 
-export const FlexRow = styled.div<{ $gap?: number | string }>`
+export const FlexRow = styled.div<{ $gap?: number | string, $wrap?: boolean }>`
   display: flex;
   flex-direction: row;
+  ${props => props.$wrap ? 'flex-wrap: wrap;' : ''}
   gap: ${(props) => props.$gap ? (typeof props.$gap === 'number' ? `${props.$gap}px` : props.$gap) : '0px'};
 ` 
-export const FlexCol = styled.div<{ $gap?: number | string }>`
+export const FlexCol = styled.div<{ $gap?: number | string, $wrap?: boolean }>`
   display: flex;
   flex-direction: column;
+  ${props => props.$wrap ? 'flex-wrap: wrap;' : ''}
   gap: ${(props) => props.$gap ? (typeof props.$gap === 'number' ? `${props.$gap}px` : props.$gap) : '0px'};
 ` 
 export const AlignedFlexRow = styled(FlexRow)`

--- a/src/components/styles/paginationBar-styles.ts
+++ b/src/components/styles/paginationBar-styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components"
 
 import { DEVICE_QUERIES } from "../../constants/other-constants"
-import { NoDecorationLink } from "../main-components"
+import { CenteredFlexRow, NoDecorationLink } from "../main-components"
 
 export const PaginationCell = styled(NoDecorationLink)`
   display: flex;
@@ -39,11 +39,7 @@ export const PaginationCell = styled(NoDecorationLink)`
     font-size: 1rem;
   }
 `
-export const PaginationCellCurrent = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
+export const PaginationCellCurrent = styled(CenteredFlexRow)`
   transition: .2s;
   background-color: #fff;
   cursor: not-allowed;
@@ -51,8 +47,6 @@ export const PaginationCellCurrent = styled.div`
   width: 2rem;
   height: 2rem;
   color: #000;
-  font-size: 1.3rem;
-  font-weight: 600;
   user-select: none;
 
   &:hover {
@@ -74,6 +68,15 @@ export const PaginationCellCurrent = styled.div`
 
   @media ${DEVICE_QUERIES.mobileL} {
     padding: 0.8rem;
-    font-size: 1rem;
+  }
+`
+
+export const PokeballImg = styled.img`
+  width: 1.7rem;
+  height: 1.7rem;
+
+  @media ${DEVICE_QUERIES.mobileL} {
+    width: 1.5rem;
+    height: 1.5rem;
   }
 `

--- a/src/pages/Filtered.tsx
+++ b/src/pages/Filtered.tsx
@@ -1,7 +1,7 @@
 import ArrayToJSXTransformer from "../components/ArrayToJSXTransformer"
 import PokemonPageLoadingFeedback from "../components/feedbacks/PokemonPageLoadingFeedback"
 import FilteringOptionsUI from "../components/FilteringOptionsUI"
-import { CenteredFlexCol, Title } from "../components/main-components"
+import { CenteredFlexCol, CenteredFlexRow, Title } from "../components/main-components"
 import PokemonPreviewCard from "../components/poke-components/PokemonPreviewCard"
 import { sanitizeTypes } from "../functions/poke-functions"
 import useFilteredPokemonsPreviewData from "../hooks/useFilteredPokemonsPreviewData"
@@ -20,7 +20,7 @@ function Filtered() {
   return (
     <CenteredFlexCol $gap="1.5rem">
       <FilteringOptionsUI/>
-      <div style={{display: "flex", flexDirection: 'row', flexFlow: 'wrap', gap: 16}}>
+      <CenteredFlexRow $gap="1rem" $wrap>
         <ArrayToJSXTransformer
           dataArray={previewData}
           transformer={(pokemon) => (
@@ -31,7 +31,7 @@ function Filtered() {
             />
           )}
         />
-      </div>
+      </CenteredFlexRow>
     </CenteredFlexCol>
   )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from "react";
 
+import PokemonLoadingMoreFeedback from "../components/feedbacks/PokemonLoadingMoreFeedback";
 import PokemonPageLoadingFeedback from "../components/feedbacks/PokemonPageLoadingFeedback";
-import { Title } from "../components/main-components";
+import { CenteredFlexCol, CenteredFlexRow, Title } from "../components/main-components";
 import PokemonPreviewCard from "../components/poke-components/PokemonPreviewCard";
 import useInfinitePokemonsPreviewData from "../hooks/useInfinitePokemonsPreviewData";
 import useOnScreen from "../hooks/useOnScreen";
@@ -26,8 +27,8 @@ function Home() {
   else if (previewData === null) return <Title $color="#fff">Something went wrong, perhaps refreshing the page will sort everything out.</Title>
 
   return (
-    <>
-      <div style={{display: "flex", flexDirection: 'row', flexWrap: 'wrap', gap: 16}}>
+    <CenteredFlexCol $gap="2rem">
+      <CenteredFlexRow $gap="1rem" $wrap>
         {previewData.map(pokemon => (
           <PokemonPreviewCard 
             id={pokemon.id} 
@@ -35,9 +36,9 @@ function Home() {
             key={`pokemon-${pokemon.id}`}
           />
         ))}
-      </div>
-      <div ref={ref}>{isLoadingMorePokemons && <h1>Loading more pokemons...</h1>}</div>
-    </>
+      </CenteredFlexRow>
+      <div ref={ref}>{isLoadingMorePokemons && <PokemonLoadingMoreFeedback/>}</div>
+    </CenteredFlexCol>
   )
 }
 


### PR DESCRIPTION
## Description

Styled the "loading more pokemons" feedback message at the end of the home page (message displayed only when fetching more pokemons).

## Motivation

It was just a simple h1 element with a message attached.

## Images

Old non styled loading more pokemons feedback.
![image](https://github.com/ArthurRodrigues01/really-simple-pokedex-app/assets/88101116/cd278602-ee20-4136-b8fb-2cc5e0b3d99e)


New styled loading more pokemons feedback.
![image](https://github.com/ArthurRodrigues01/really-simple-pokedex-app/assets/88101116/d95b17a5-6c5f-4707-a861-54f3b3295738)


## Current behavior

Non styled loading more pokemons feedback message.

## Expected behavior

Styled loading more pokemons feedback message.

## Describe changes

- Added "PokemonLoadingMoreFeeback" component.