### PR TITLE
feature: higher pokemon quantity displayed mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.13.0</title>
+    <title>Really Simple Pokedex V1.14.0</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.13.0" ,
+  "version": "1.14.0" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
+++ b/src/components/feedbacks/PokemonPreviewCardLoadingFeedback.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from "react"
 
 import { NoDecorationLink, Title } from "../main-components"
-import { PokemonPreviewCardWrapper } from "../poke-components/main-poke-components"
+import { PokemonPreviewCardWrapper } from "../styles/pokemonPreviewCard-styles"
 import HoverableGrowthFeedback from "./HoverableGrowthFeedback"
-import RotatingPokeballFeedback from "./RotatingPokeballFeedback"
+import RotatingPokeballFeedbackPreviewCard from "./RotatingPokeballFeedbackPreviewCard"
 
 const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement, 
 { 
@@ -13,13 +13,13 @@ const PokemonPreviewCardLoadingFeedback = forwardRef<HTMLDivElement,
   (props, ref) => {
   return (
     <HoverableGrowthFeedback
-      $borderBottomRightRadius={'1rem'} 
-      $borderTopLeftRadius={'1rem'}
+      $borderBottomRightRadius={'3rem'} 
+      $borderTopLeftRadius={'3rem'}
     >
       <NoDecorationLink to={`/pokemon/${props.id}`}>
         <PokemonPreviewCardWrapper ref={ref}>
           <Title $color="#fff">{props.name}</Title>
-          <RotatingPokeballFeedback pokemonId={props.id}/>
+          <RotatingPokeballFeedbackPreviewCard pokemonId={props.id}/>
           <Title $color="#fff">Loading...</Title>
         </PokemonPreviewCardWrapper>
       </NoDecorationLink>

--- a/src/components/feedbacks/RotatingPokeballFeedbackPreviewCard.tsx
+++ b/src/components/feedbacks/RotatingPokeballFeedbackPreviewCard.tsx
@@ -1,0 +1,36 @@
+import styled from "styled-components"
+
+import { DEVICE_QUERIES } from "../../constants/other-constants"
+import Rotate from "../Rotate"
+
+const PokeballImg = styled.img`
+  width: 250px;
+  height: 250px;
+
+  @media ${DEVICE_QUERIES.tablet} {
+    width: 200px;
+    height: 200px;
+  }
+  
+  @media ${DEVICE_QUERIES.mobileL} {
+    width: 125px;
+    height: 125px;
+  }
+  @media ${DEVICE_QUERIES.mobileM} {
+    width: 100px;
+    height: 100px;
+  }
+`
+
+function RotatingPokeballFeedbackPreviewCard({ pokemonId }: { pokemonId?: number | string }) {
+  return (
+    <Rotate>
+      <PokeballImg 
+        src={"/really-simple-pokedex-app/pokeball.svg"} 
+        alt={pokemonId ? `Loading pokemon ${pokemonId}` : 'Loading'} 
+      />
+    </Rotate>
+  )
+}
+
+export default RotatingPokeballFeedbackPreviewCard

--- a/src/components/main-components.ts
+++ b/src/components/main-components.ts
@@ -54,16 +54,23 @@ export const CenteredGridCol = styled(GridCol)`
   justify-content: center;
 `
 export const Title = styled.h1<{ $color?: string }>`
-  font-size: 2.5rem;
   color: ${props => props.$color || '#000'};
+  font-size: 2.5rem;
+
 
   @media ${DEVICE_QUERIES.tablet} {
     font-size: 2rem;
   }
-
   @media ${DEVICE_QUERIES.mobileL} {
     font-size: 1.7rem;
   }
+`
+export const EllipsedText = styled(Title)<{ $centeredText?: boolean}>`
+  width: 100%;
+  overflow: hidden;
+  ${props => props.$centeredText ? 'text-align: center;' : ''}
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `
 export const SubTitle = styled(Title)`
   font-size: 1.5rem;

--- a/src/components/poke-components/PokemonPreviewCard.tsx
+++ b/src/components/poke-components/PokemonPreviewCard.tsx
@@ -6,12 +6,8 @@ import useOnScreen from "../../hooks/useOnScreen";
 import useSinglePokemonData from "../../hooks/useSinglePokemonData";
 import HoverableGrowthFeedback from "../feedbacks/HoverableGrowthFeedback";
 import PokemonPreviewCardLoadingFeedback from "../feedbacks/PokemonPreviewCardLoadingFeedback";
-import { NoDecorationLink, Title } from "../main-components";
-import {
-  PokemonPreviewCardWrapper,
-  PokemonSprite,
-  PokemonSpriteWrapper
-} from "./main-poke-components";
+import { EllipsedText, NoDecorationLink } from "../main-components";
+import { PokemonPreviewCardWrapper, PokemonSpritePreviewCard, PokemonSpriteWrapperPreviewCard } from "../styles/pokemonPreviewCard-styles";
 
 function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
   const { ref, isVisible } = useOnScreen()
@@ -33,17 +29,17 @@ function PokemonPreviewCard({ id, name }: { id: number, name: string }) {
 
   return (
     <HoverableGrowthFeedback 
-      $borderBottomRightRadius={'4rem'} 
-      $borderTopLeftRadius={'4rem'}
+      $borderBottomRightRadius={'3rem'} 
+      $borderTopLeftRadius={'3rem'}
       $outline
     >
       <NoDecorationLink to={`/pokemon/${data.id}`} style={{borderBottomRightRadius: '4rem', borderTopLeftRadius: '4rem'}}>
         <PokemonPreviewCardWrapper ref={ref} $backgroundColor={getPokemonTypeColor(data.types[0])}>
-          <Title $color="#fff">{data.name}</Title>
-          <PokemonSpriteWrapper>
-            <PokemonSprite src={data.spriteSrc} alt={`pokemon ${data.id}`}/>
-          </PokemonSpriteWrapper>
-          <Title $color="#fff">#{data.id}</Title>
+          <EllipsedText $centeredText $color="#fff">{data.name}</EllipsedText>
+          <PokemonSpriteWrapperPreviewCard>
+            <PokemonSpritePreviewCard src={data.spriteSrc} alt={`pokemon ${data.id}`}/>
+          </PokemonSpriteWrapperPreviewCard>
+          <EllipsedText $centeredText $color="#fff">#{data.id}</EllipsedText>
         </PokemonPreviewCardWrapper>
       </NoDecorationLink>
     </HoverableGrowthFeedback>

--- a/src/components/poke-components/main-poke-components.ts
+++ b/src/components/poke-components/main-poke-components.ts
@@ -4,51 +4,31 @@ import { DEVICE_QUERIES } from "../../constants/other-constants";
 import { POKEMON_IMAGE_WRAPPER_BG_COLOR } from "../../constants/pokemon-related-constants";
 import { CenteredFlexCol } from "../main-components";
 
-export const PokemonPreviewCardWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string }>`
-  border-top-left-radius: 4rem;
-  border-bottom-right-radius: 4rem;
-  background-color: ${props => props.$backgroundColor || '#d4d4d4'};
-  padding: 1.5rem;
-  width: calc(250px + 3rem);
-  text-overflow: ellipsis;
-  gap: 1.5rem;
-
-  @media ${DEVICE_QUERIES.tablet} {
-    width: calc(170px + 2rem);
-    padding: 1rem;
-    gap: 1rem;
-  }
-
-  @media ${DEVICE_QUERIES.mobileL} {
-    width: calc(120px + 3rem);
-  }
-`
 export const PokemonSpriteWrapper = styled(CenteredFlexCol)`
   border-radius: 999px;
   background-color: ${POKEMON_IMAGE_WRAPPER_BG_COLOR};
-  height: 250px;
   width: 250px;
+  height: 250px;
 
   @media ${DEVICE_QUERIES.tablet} {
+    width: 200px; 
     height: 200px;
-    width: 200px;
   }
   @media ${DEVICE_QUERIES.mobileL} {
-    height: 150px;
     width: 150px;
+    height: 150px;
   }
 `
 export const PokemonSprite = styled.img`
   width: auto;
-  height: auto;
   max-width: 175px;
+  height: auto;
   max-height: 175px;
   
   @media ${DEVICE_QUERIES.tablet} {
     max-width: 150px;
     max-height: 150px;
   }
-
   @media ${DEVICE_QUERIES.mobileL} {
     max-width: 100px;
     max-height: 100px;

--- a/src/components/styles/pokemonPreviewCard-styles.ts
+++ b/src/components/styles/pokemonPreviewCard-styles.ts
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+
+import { DEVICE_QUERIES } from "../../constants/other-constants";
+import { CenteredFlexCol } from "../main-components";
+import { PokemonSprite, PokemonSpriteWrapper } from "../poke-components/main-poke-components";
+
+export const PokemonPreviewCardWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string }>`
+  border-top-left-radius: 3rem;
+  border-bottom-right-radius: 3rem;
+  background-color: ${props => props.$backgroundColor || '#d4d4d4'};
+  padding: 1.5rem;
+  width: calc(250px + 3rem);
+  gap: 1.5rem;
+
+  @media ${DEVICE_QUERIES.tablet} {
+    padding: 1rem;
+    width: 200px;
+    gap: 1rem;  
+  }
+  @media ${DEVICE_QUERIES.mobileL} {
+    width: calc(125px + 1rem);
+  }
+  @media ${DEVICE_QUERIES.mobileM} {
+    width: calc(100px + 1rem);
+    gap: .7rem;
+  }
+`
+
+export const PokemonSpriteWrapperPreviewCard = styled(PokemonSpriteWrapper)`
+  @media ${DEVICE_QUERIES.tablet} {
+    width: 200px; 
+    height: 200px;
+  }
+  @media ${DEVICE_QUERIES.mobileL} {
+    width: 125px;
+    height: 125px;
+  }
+  @media ${DEVICE_QUERIES.mobileM} {
+    width: 100px;
+    height: 100px;
+  }
+`
+
+export const PokemonSpritePreviewCard = styled(PokemonSprite)`
+  @media ${DEVICE_QUERIES.tablet} {
+    max-width: 150px;
+    max-height: 150px;
+  }
+  @media ${DEVICE_QUERIES.mobileL} {
+    max-width: 95px;
+    max-height: 95px;
+  }
+  @media ${DEVICE_QUERIES.mobileM} {
+    max-width: 75px;
+    max-height: 75px;
+  }
+`


### PR DESCRIPTION
## Description

Changed the dimensions of "PokemonPreviewCard" and some its child while on smaller screen sizes so that at least two of Pokemon Cards could show at the same time.

## Motivation

It took ages just to get to gen 3 pokemons, it still take ages to go through all pokemons but at least it is more manageable now.

## Current behavior

Only able to display one pokemon card per row at home page.

## Expected behavior

Able to display at least two pokemon cards per row at home page.

## Describe changes

- Altered "PokemonPreviewCard" so that its dimensions would be just big enough for two of them to be displayed at the same time on smaller screen sizes.