### PR TITLE
fixed: filtering menu mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.15.0</title>
+    <title>Really Simple Pokedex V1.15.1</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.15.0" ,
+  "version": "1.15.1" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/FilteringMenu.tsx
+++ b/src/components/FilteringMenu.tsx
@@ -49,9 +49,11 @@ function FilteringMenu() {
             <FilterType
               type={activeFilter.name}
               onClick={() => deactivateFilterHandler(activeFilter)}
+              key={`active-filter-type-${activeFilter.name}`}
             /> : 
             <Filter
               onClick={() => deactivateFilterHandler(activeFilter)}
+              key={`active-filter-gen-${activeFilter.name}`}
             >
               {`Gen ${activeFilter.name}`}
             </Filter>

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -19,6 +19,7 @@ export const FeedbackedButton = styled.button`
 
   @media ${DEVICE_QUERIES.tablet} {
     padding: 1rem 1.5rem;
+    font-size: 1.5rem;
   }
     
   &: hover {

--- a/src/components/styles/filteringMenu-styles.tsx
+++ b/src/components/styles/filteringMenu-styles.tsx
@@ -14,6 +14,11 @@ export const FilteringMenuWrapper = styled.div`
   transition: all 0.3s ease-in-out;
   width: 560px;
   z-index: 1000;
+
+  @media ${DEVICE_QUERIES.tablet} {
+    right: 0;
+    width: 100%;
+  }
 `
 export const FilteringMenuTitleWrapper = styled(FlexRow)`
   align-items: center;
@@ -22,7 +27,7 @@ export const FilteringMenuTitleWrapper = styled(FlexRow)`
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   background-color: #777;
-  padding: 2rem;
+  padding: 1rem 2rem;
 `
 export const FilteringMenuContent = styled(FlexCol)`
   background-color: #666;
@@ -37,6 +42,11 @@ export const ActiveFilters = styled(FlexRow)`
   overflow-x: auto;
   overflow-y: hidden;
   gap: 2rem;
+  align-items: center;
+
+  @media ${DEVICE_QUERIES.tablet} {
+    height: 2.5rem;
+  }
 `
 export const OtherFilters = styled(FlexRow)`
   flex-wrap: wrap;
@@ -46,6 +56,10 @@ export const OtherFilters = styled(FlexRow)`
   height: 10rem;
   overflow-y: scroll;
   gap: 2rem;
+
+  @media ${DEVICE_QUERIES.tablet} {
+    height: 5rem;
+  }
 `
 export const HideFilteringMenuButton = styled.img<{ $show?: boolean}>`
   transition: all 0.3s ease-in-out;
@@ -64,6 +78,10 @@ const FilterBase = styled(CenteredFlexRow)`
   color: #fff;
   font-size: 1.5rem;
   font-weight: bold;
+
+  @media ${DEVICE_QUERIES.tablet} {
+    font-size: 1.2rem
+  }
 `
 export const FiltersWrapper = styled(CenteredFlexRow)`
   flex-wrap: wrap;


### PR DESCRIPTION
## Description

Fixed filtering menu for mobile users (below 738px screen width).

## Motivation

Just completely forgot about mobile while developing this component, it's displaying for mobile was broken. 

## Images

Old filtering menu for mobile
![image](https://github.com/ArthurRodrigues01/really-simple-pokedex-app/assets/88101116/aaae474c-30e5-4426-ae65-92436882a525)


New filtering menu for mobile
![image](https://github.com/ArthurRodrigues01/really-simple-pokedex-app/assets/88101116/39d5aa4c-2cd7-4c77-b731-ef30839d5de4)


## Current behavior

Filtering menu display is broken in mobile.

## Expected behavior

Filtering menu display works just fine in mobile.

## Describe changes

- Altered "filteringMenu-styles": added media queries for some components.