### PR TITLE
fixed: use filtered pokemons hook

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.16.0</title>
+    <title>Really Simple Pokedex V1.16.1</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.16.0" ,
+  "version": "1.16.1" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -28,6 +28,22 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
   }
 
   const sanitized = [previewDataGen, previewDataTypes].filter(item => item !== null)
+  const demandedItems = [options.gen, options.types].filter(item => {
+    if (item !== undefined) {
+      if (Array.isArray(item) && item.length !== 0) {
+        return item
+      } else if (Array.isArray(item) === false) {
+        return item
+      }
+    }
+  })
+
+  if (sanitized.length < demandedItems.length) {
+    return {
+      previewData: null,
+      isLoading: false
+    }
+  }
 
   const reducedData = sanitized.reduce((prev, curr, index) => {
     if (index === 0) return curr!

--- a/src/hooks/usePokemonsPreviewDataGen.ts
+++ b/src/hooks/usePokemonsPreviewDataGen.ts
@@ -2,7 +2,8 @@ import { useQuery } from "@tanstack/react-query"
 
 import { isInRange, isNaturalNumber } from "../functions/other-functions"
 import { getPokemonPreviewDataFromArray } from "../functions/poke-functions"
-import { GenPage, PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
+import { GenPage } from "../types/pokemon-api-page-types"
+import { PokemonsPreviewDataStatus } from "../types/pokemon-related-types"
 
 function usePokemonsPreviewDataGen(gen: number): PokemonsPreviewDataStatus {
   const { data, isLoading } = useQuery({

--- a/src/hooks/usePokemonsPreviewDataTypes.ts
+++ b/src/hooks/usePokemonsPreviewDataTypes.ts
@@ -6,10 +6,10 @@ import {
   getPokemonPreviewDataFromArray,
   removeNonSpeciesFromArray
 } from "../functions/poke-functions"
+import { PokemonTypePage } from "../types/pokemon-api-page-types"
 import {
   NamedAPIResource,
   NamedAPIResourceList,
-  PokemonTypePage,
   PokemonsPreviewDataStatus
 } from "../types/pokemon-related-types"
 


### PR DESCRIPTION
## Description

fixed "useFilteredPokemonsPreviewData" hook.

## Motivation

Basically this hook was causing problems because of the way it was designed, it always made requests to fetch pokemon from both gen and types if the user didn't apply the gen it defaulted to NaN which was filtered and returned null, if the user applied for no type it defaulted to an empty array ([ ]) which were filtered and returned null, and the results were just sanitized to remove null results before being reduced it a single array of same common objects between results (basically if types result was null, it just ignored it and returned only the gen results). The problem is,

What if the user applied for types and gens, and it just happened that the results for such combination of types returned null because there was no such combination?
(an example is fairy and fire, which there is no pokemon with this combination of types)

well the hook sanitized the results which were null, out, before reducing and getting the same objects in both arrays, but since the results for type were null, it returned  only the gen results, which is not what was supposed to happen, it was suppose to return a message describing that there were no results.

## Current behavior

Not handling no results for types situation.

## Expected behavior

Handling no results for types situation.

## Describe changes

- Altered "useFilteredPokemonsPreviewData" hook: It was fixed by checking what the user requested and what was received, and if what was received was less than what was requested, it returns null.