### PR TITLE
fixed: wrong feedback use filtered pokemons hook

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.16.1</title>
+    <title>Really Simple Pokedex V1.16.2</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.16.1",
+      "version": "1.16.2",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.16.1" ,
+  "version": "1.16.2" ,
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/hooks/useFilteredPokemonsPreviewData.ts
+++ b/src/hooks/useFilteredPokemonsPreviewData.ts
@@ -38,7 +38,11 @@ function useFilteredPokemonsPreviewData(options: PokemonFilteringOptions): Pokem
     }
   })
 
-  if (sanitized.length < demandedItems.length) {
+  if (
+    sanitized.length < demandedItems.length && 
+    isLoadingGen === false && 
+    isLoadingTypes === false
+  ) {
     return {
       previewData: null,
       isLoading: false

--- a/src/pages/Filtered.tsx
+++ b/src/pages/Filtered.tsx
@@ -8,9 +8,11 @@ import useURLSearchParams from "../hooks/useURLSearchParams"
 
 function Filtered() {
   const searchParams = useURLSearchParams()
+  const gen = Number(searchParams.gen)
+  const types = sanitizeTypes([searchParams.type1, searchParams.type2])
   const { previewData, isLoading } = useFilteredPokemonsPreviewData({
-    gen: Number(searchParams.gen),
-    types: sanitizeTypes([searchParams.type1, searchParams.type2])
+    gen: gen,
+    types: types
   }) 
 
   if (isLoading) return (


### PR DESCRIPTION
## Description

It would appear that there were no pokemons found for brief moments before being displayed the fetched results.

## Motivation

It was odd, even for brief moments.

## Current behavior

Issue not addressed, still displaying wrong feedback sometimes.

## Expected behavior

Issue addressed, display correct feedback all times.

## Describe changes

- Altered "useFilteredPokemonsPreviewData" hook: now checks for the loading status of both gen and type requests while comparing demanded items and received items.