### PR TITLE
feature: display weaknesses

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/pokeball.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Really Simple Pokedex V1.18.0</title>
+    <title>Really Simple Pokedex V1.19.0</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "really-simple-pokedex",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "really-simple-pokedex",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "dependencies": {
         "@tanstack/react-query": "^5.29.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "really-simple-pokedex",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "homepage": "https://arthurrodrigues.github.io/really-simple-pokedex-app",
   "scripts": {

--- a/src/components/poke-components/PokemonCard.tsx
+++ b/src/components/poke-components/PokemonCard.tsx
@@ -3,34 +3,26 @@ import {
   getPokemonWrapperTypeColor
 } from "../../functions/poke-functions"
 import { PokedexEntry, PokemonAbility } from "../../types/pokemon-related-types"
-import { CenteredFlexCol, SubTitle, Text, Title } from "../main-components"
+import { CenteredFlexCol, Title } from "../main-components"
 import { PokemonType, PokemonTypesWrapper } from "../styles"
 import {
   PokemonAbilities,
-  PokemonCardGridArea,
   PokemonCardWrapper,
   PokemonFlavorTextsWrapper,
   PokemonPokedexEntry,
+  PokemonSpritePokemonCard,
+  PokemonSpriteWrapperPokemonCard,
   PokemonStatsWrapper,
 } from "../styles/pokemonCard-styles"
-import { PokemonSprite, PokemonSpriteWrapper } from "./main-poke-components"
 
-function PokemonCard({ 
-  id, 
+function PokemonCard({
   name, 
   spriteSrc, 
-  height, 
-  weight, 
   types, 
-  gen, 
   pokedexEntries,
   abilities,
 }: {
-  id: number;
-  gen: number;
   name: string;
-  weight: number;
-  height: number;
   types: string[];
   spriteSrc: string;
   pokedexEntries: PokedexEntry[];
@@ -42,19 +34,20 @@ function PokemonCard({
       <PokemonStatsWrapper $backgroundColor={getPokemonTypeColor(types[0])}>
         <CenteredFlexCol $gap={'1.5rem'}>
           <Title>{name}</Title>
-          <PokemonSpriteWrapper>
-            <PokemonSprite src={`${spriteSrc}`} width={250} height={250}/>
-          </PokemonSpriteWrapper>
-        </CenteredFlexCol>
-        <PokemonCardGridArea $gap='1.5rem'>
-          <SubTitle>ID: <Text>{id}</Text></SubTitle>
-          <SubTitle>Gen: <Text>{gen}</Text></SubTitle>
-          <SubTitle>Height: <Text>{height}m</Text></SubTitle>
-          <SubTitle>Weight: <Text>{weight}kg</Text></SubTitle>
+          <PokemonSpriteWrapperPokemonCard>
+            <PokemonSpritePokemonCard 
+              src={`${spriteSrc}`}
+            />
+          </PokemonSpriteWrapperPokemonCard>
           <PokemonTypesWrapper>
-            {types.map(type => <PokemonType key={`pokemon-type-${type}`} type={type}/>)}
+            {types.map(type => (
+              <PokemonType 
+                key={`pokemon-type-${type}`} 
+                type={type}
+              />
+            ))}
           </PokemonTypesWrapper>
-        </PokemonCardGridArea>
+        </CenteredFlexCol>
       </PokemonStatsWrapper>
       <PokemonFlavorTextsWrapper 
         $backgroundColor={getPokemonWrapperTypeColor(types[0])}

--- a/src/components/poke-components/PokemonDetails.tsx
+++ b/src/components/poke-components/PokemonDetails.tsx
@@ -1,0 +1,63 @@
+import { getPokemonTypeColor, getPokemonWrapperTypeColor } from "../../functions/poke-functions"
+import { AlignedFlexRow, SubTitle, Text, Title } from "../main-components"
+import {
+  PokemonSectionTitleWrapper,
+  PokemonType,
+  PokemonTypesWrapper,
+  SectionWrapper
+} from "../styles"
+import {
+  PokemonDetailsGridArea,
+  PokemonDetailsWrapper
+} from "../styles/pokemonDetails-styles"
+
+function PokemonDetails({
+  id,
+  height,
+  weight,
+  gen,
+  types,
+  weaknesses,
+} : {
+  id: number,
+  height: number,
+  weight: number,
+  gen: number,
+  types: string[],
+  weaknesses: string[]
+}) {
+  return ( 
+    <SectionWrapper>
+      <PokemonSectionTitleWrapper $backgroundColor={getPokemonTypeColor(types[0])}>
+        <Title>Pokemon Details</Title>
+      </PokemonSectionTitleWrapper>
+      <PokemonDetailsWrapper $backgroundColor={getPokemonWrapperTypeColor(types[0])}>
+        <PokemonDetailsGridArea $gap={'1.5rem'}>
+          <SubTitle>ID: <Text>{id}</Text></SubTitle>
+          <SubTitle>Gen: <Text>{gen}</Text></SubTitle>
+          <SubTitle>Height: <Text>{height}m</Text></SubTitle>
+          <SubTitle>Weight: <Text>{weight}kg</Text></SubTitle>
+          <AlignedFlexRow $gap={'1rem'} $wrap>
+            <SubTitle>Weaknesses: </SubTitle> 
+            <PokemonTypesWrapper $wrap>
+              {
+                weaknesses.length !== 0 ?
+                
+                weaknesses.map(weakness => (
+                  <PokemonType
+                    key={`pokemon-weakness-${weakness}`} 
+                    type={weakness}
+                  />
+                )) :
+
+                <SubTitle $color="#000">None</SubTitle>
+              }
+            </PokemonTypesWrapper>
+          </AlignedFlexRow>
+        </PokemonDetailsGridArea>
+      </PokemonDetailsWrapper>
+    </SectionWrapper>
+  )
+}
+
+export default PokemonDetails

--- a/src/components/poke-components/PokemonEvolutionChain.tsx
+++ b/src/components/poke-components/PokemonEvolutionChain.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { getEvolutionChains, getPokemonTypeColor, getPokemonWrapperTypeColor } from "../../functions/poke-functions";
+import {
+  getEvolutionChains,
+  getPokemonTypeColor,
+  getPokemonWrapperTypeColor
+} from "../../functions/poke-functions";
 import { ChainLink, PokemonPreviewData } from "../../types/pokemon-related-types";
 import { Title } from "../main-components";
 import { PokemonSectionTitleWrapper, SectionWrapper } from "../styles";
-import { PokemonEvolutionChainGridArea, PokemonEvolutionChainGridCell, PokemonEvolutionChainWrapper } from "../styles/pokemonEvolutionChain-styles";
+import {
+  PokemonEvolutionChainGridArea,
+  PokemonEvolutionChainGridCell,
+  PokemonEvolutionChainWrapper
+} from "../styles/pokemonEvolutionChain-styles";
 import PokemonChainLink from "./PokemonChainLink";
 import PokemonEvolutionChainArrow from "./PokemonEvolutionChainArrow";
 

--- a/src/components/poke-components/main-poke-components.ts
+++ b/src/components/poke-components/main-poke-components.ts
@@ -15,22 +15,22 @@ export const PokemonSpriteWrapper = styled(CenteredFlexCol)`
     height: 200px;
   }
   @media ${DEVICE_QUERIES.mobileL} {
-    width: 150px;
-    height: 150px;
+    width: 140px;
+    height: 140px;
   }
 `
 export const PokemonSprite = styled.img`
   width: auto;
-  max-width: 175px;
+  max-width: calc(250px * 0.7);
   height: auto;
-  max-height: 175px;
+  max-height: calc(250px * 0.7);
   
   @media ${DEVICE_QUERIES.tablet} {
-    max-width: 150px;
-    max-height: 150px;
+    max-width: calc(200px * 0.7);
+    max-height: calc(200px * 0.7);
   }
   @media ${DEVICE_QUERIES.mobileL} {
-    max-width: 100px;
-    max-height: 100px;
+    max-width: calc(140px * 0.7);
+    max-height: calc(140px * 0.7);
   }
 `

--- a/src/components/styles.tsx
+++ b/src/components/styles.tsx
@@ -27,8 +27,8 @@ export const FeedbackedButton = styled.button`
   }
 `
 export const PokemonSectionTitleWrapper = styled.div<{ $backgroundColor: string }>`
-  border-top-left-radius: 4rem;
-  border-top-right-radius: 4rem;
+  border-top-left-radius: 2.5rem;
+  border-top-right-radius: 2.5rem;
   background-color: ${props => props.$backgroundColor};
   padding: 2rem 2rem;
   width: 950px;
@@ -48,9 +48,9 @@ export const DivGap = styled.div`
   }
 `
 export const PokemonTypesWrapper = styled(CenteredFlexRow)`
-  border-radius: 4rem;
+  border-radius: 1.5rem;
   background-color: #fff;
-  padding: 0.5rem;    
+  padding: .5rem;    
   gap: 1rem;
 `
 const PokemonTypeWrapper = styled(CenteredFlexRow)`

--- a/src/components/styles/paginationBar-styles.ts
+++ b/src/components/styles/paginationBar-styles.ts
@@ -21,12 +21,12 @@ export const PaginationCell = styled(NoDecorationLink)`
     background-color: #d4d4d4;
   }
   &: first-child {
-    border-top-left-radius: 2rem;
-    border-bottom-left-radius: 2rem;
+    border-top-left-radius: 1rem;
+    border-bottom-left-radius: 1rem;
   }
   &: last-child {
-    border-top-right-radius: 2rem;
-    border-bottom-right-radius: 2rem;
+    border-top-right-radius: 1rem;
+    border-bottom-right-radius: 1rem;
   }
 
   @media ${DEVICE_QUERIES.tablet} {
@@ -53,12 +53,12 @@ export const PaginationCellCurrent = styled(CenteredFlexRow)`
     background-color: #d4d4d4;
   }
   &: first-child {
-    border-top-left-radius: 1000px;
-    border-bottom-left-radius: 1000px;
+    border-top-left-radius: 1rem;
+    border-bottom-left-radius: 1rem;
   }
   &: last-child {
-    border-top-right-radius: 1000px;
-    border-bottom-right-radius: 1000px;
+    border-top-right-radius: 1rem;
+    border-bottom-right-radius: 1rem;
   }
 
   @media ${DEVICE_QUERIES.tablet} {

--- a/src/components/styles/pokemonCard-styles.tsx
+++ b/src/components/styles/pokemonCard-styles.tsx
@@ -5,15 +5,33 @@ import { PokemonAbility } from "../../types/pokemon-related-types";
 import {
   CenteredFlexCol,
   CenteredFlexRow,
-  CenteredGridRow,
   FlexCol,
   Text,
   Title
 } from "../main-components";
+import { PokemonSprite, PokemonSpriteWrapper } from "../poke-components/main-poke-components";
 
+export const PokemonSpriteWrapperPokemonCard = styled(PokemonSpriteWrapper)`
+  width: 320px;
+  height: 320px;
+
+  @media ${DEVICE_QUERIES.mobileM} {
+    width: 240px;
+    height: 240px;
+  }
+`
+export const PokemonSpritePokemonCard = styled(PokemonSprite)`
+  max-width: calc(320px * 0.7);
+  max-height: calc(320px * 0.7);
+
+  @media ${DEVICE_QUERIES.mobileM} {
+    max-width: calc(240px * 0.7);
+    max-height: calc(240px * 0.7);
+  }
+`
 export const PokemonCardWrapper = styled(CenteredFlexRow)`
   width: calc((2rem * 2) + 950px);  
-
+  
   @media ${DEVICE_QUERIES.laptop} {
     align-self: stretch;
     width: auto;
@@ -24,7 +42,8 @@ export const PokemonCardWrapper = styled(CenteredFlexRow)`
   }
 `
 export const PokemonStatsWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: string}>`
-  border-top-left-radius: 4rem;
+  align-self: stretch;
+  border-top-left-radius: 2rem;
   background-color: ${(props) => props.$backgroundColor ? props.$backgroundColor : '#d4d4d4'};
   padding: 1.5rem;
   width: 40%;
@@ -42,9 +61,9 @@ export const PokemonStatsWrapper = styled(CenteredFlexCol)<{ $backgroundColor?: 
   }
 `
 export const PokemonFlavorTextsWrapper = styled(FlexCol)<{ $backgroundColor?: string}>`
-  justify-content: space-around;
   align-self: stretch;  
-  border-bottom-right-radius: 4rem;
+  justify-content: space-around;
+  border-bottom-right-radius: 2.5rem;
   background-color: ${props => props.$backgroundColor ? props.$backgroundColor : '#d4d4d4'};
   padding: 1.5rem;
   width: 60%;
@@ -96,7 +115,3 @@ export const PokemonAbilities = ({abilities}: {abilities: PokemonAbility[]}) => 
     </PokemonAbilitiesWrapper>
   </FlexCol>
 )
-
-export const PokemonCardGridArea = styled(CenteredGridRow)`
-  text-align: center;
-`

--- a/src/components/styles/pokemonDetails-styles.tsx
+++ b/src/components/styles/pokemonDetails-styles.tsx
@@ -1,0 +1,28 @@
+import styled from "styled-components"
+
+import { DEVICE_QUERIES } from "../../constants/other-constants"
+import { CenteredGridRow, FlexRow } from "../main-components"
+
+export const PokemonDetailsWrapper = styled(FlexRow)<{ $backgroundColor: string }>`
+  border-bottom-left-radius: 2.5rem;
+  border-bottom-right-radius: 2.5rem;
+  background-color: ${props => props.$backgroundColor};
+  padding: 2rem;
+  width: 950px;
+  gap: 2rem;
+  
+  @media ${DEVICE_QUERIES.laptop} {
+    flex-wrap: wrap;
+    align-self: stretch;
+    width: auto;
+    border-radius: 0;
+  }
+`
+
+export const PokemonDetailsGridArea = styled(CenteredGridRow)`
+  grid-template-columns: auto auto;
+  
+  @media ${DEVICE_QUERIES.tablet} {
+    grid-template-columns: auto;
+  }
+`

--- a/src/components/styles/pokemonEvolutionChain-styles.tsx
+++ b/src/components/styles/pokemonEvolutionChain-styles.tsx
@@ -4,8 +4,8 @@ import { DEVICE_QUERIES } from "../../constants/other-constants";
 import { CenteredFlexCol, CenteredFlexRow } from "../main-components";
 
 export const PokemonEvolutionChainWrapper = styled(CenteredFlexRow)<{ $backgroundColor: string }>`
-  border-bottom-left-radius: 4rem;
-  border-bottom-right-radius: 4rem;
+  border-bottom-left-radius: 2.5rem;
+  border-bottom-right-radius: 2.5rem;
   background-color: ${props => props.$backgroundColor};
   padding: 2rem;
   width: 950px;
@@ -27,8 +27,8 @@ export const PokemonEvolutionChainGridArea = styled.div<{
   grid-auto-columns: 175px;
   grid-auto-flow: row;
   justify-content: center;
-  border-bottom-left-radius: 4rem;
-  border-bottom-right-radius: 4rem;
+  border-bottom-left-radius: 2.5rem;
+  border-bottom-right-radius: 2.5rem;
   background-color: ${props => props.$backgroundColor};
   padding: 2rem;
   width: 950px;

--- a/src/components/styles/pokemonVarieties-styles.tsx
+++ b/src/components/styles/pokemonVarieties-styles.tsx
@@ -5,8 +5,8 @@ import { CenteredFlexRow } from "../main-components";
 
 export const PokemonVarietiesWrapper = styled(CenteredFlexRow)<{ $backgroundColor: string }>`
   flex-wrap: wrap;
-  border-bottom-left-radius: 4rem;
-  border-bottom-right-radius: 4rem;
+  border-bottom-left-radius: 2.5rem;
+  border-bottom-right-radius: 2.5rem;
   background-color: ${props => props.$backgroundColor};
   padding: 2rem;
   width: 950px;

--- a/src/functions/testing.test.ts
+++ b/src/functions/testing.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@jest/globals'
 
+import { getPokemonData } from './poke-functions'
+
 test('testing', async () => {
-  expect(0.4 === 0.4).toBe(true)
+  expect((await getPokemonData(260))?.weaknesses).toEqual(['grass'])
 })

--- a/src/pages/SinglePokemon.tsx
+++ b/src/pages/SinglePokemon.tsx
@@ -5,6 +5,7 @@ import PokemonPageLoadingFeedback from "../components/feedbacks/PokemonPageLoadi
 import { CenteredFlexCol } from "../components/main-components"
 import PaginationBar from "../components/PaginationBar"
 import PokemonCard from "../components/poke-components/PokemonCard"
+import PokemonDetails from "../components/poke-components/PokemonDetails"
 import PokemonEvolutionChain from "../components/poke-components/PokemonEvolutionChain"
 import PokemonVarieties from "../components/poke-components/PokemonVarieties"
 import useSinglePokemonData from "../hooks/useSinglePokemonData"
@@ -26,15 +27,19 @@ function SinglePokemon() {
   return (
     <CenteredFlexCol $gap="1.5rem">
       <PokemonCard
-        id={data.id}
         name={data.name}
-        gen={data.gen}
-        height={data.height}
-        weight={data.weight}
         spriteSrc={data.spriteSrc}
         types={data.types}
         pokedexEntries={data.pokedexEntries}
         abilities={data.abilities}
+      />
+      <PokemonDetails
+        id={data.id}
+        height={data.height}
+        weight={data.weight}
+        gen={data.gen}
+        types={data.types}
+        weaknesses={data.weaknesses}
       />
       <PokemonEvolutionChain 
         chainLink={data.evolutionChain}

--- a/src/types/pokemon-related-types.ts
+++ b/src/types/pokemon-related-types.ts
@@ -16,6 +16,7 @@ export type PokemonData = {
   weight: number,
   height: number,
   types: string[],
+  weaknesses: string[],
   spriteSrc: string,
   pokedexEntries: PokedexEntry[],
   maxNumberOfPokemons: number,


### PR DESCRIPTION
## Description

Now Displaying a pokemon's weaknesses on single pokemon pages.

## Motivation

More content.

## Images

Old Single Pokemon Page layout (without weakness):
![image](https://github.com/user-attachments/assets/c9907164-8a2e-464a-846c-01f1e2d7573d)


New Single Pokemon page layout (with weakness):
![image](https://github.com/user-attachments/assets/f4847741-c7ca-414d-b68c-45ecc2ee1956)

## Current behavior

Not displaying a pokemon's weaknesses on single pokemon pages (and old layout).

## Expected behavior

Displaying a pokemon's weaknesses on single pokemon pages (and new layout).

## Describe changes

- Added "PokemonDetails" component.
- Altered "PokemonCard" component.